### PR TITLE
Saves legacy user data in native auth storage

### DIFF
--- a/build.html
+++ b/build.html
@@ -98,5 +98,22 @@
       </form>
       <div class="resend-code-area two-factor-resend btn btn-link hidden">Send new code</div>
     </div>
+    <div class="state future" data-state="force-update-pass">
+      <h3 class="aligncenter">Your password needs to be updated</h3>
+      <p>Your organization has updated its password policy and you will need to update your password to keep meeting the security requirements.</p>
+      <form class="fliplet-force-update-password">
+        <div class="form-group clearfix ">
+          <input type="password" class="form-control force-update-new-password" name="force-update-new-password" placeholder="Enter new password" required>
+        </div>
+        <div class="form-group clearfix ">
+          <input type="password" class="form-control force-update-confirm-password" name="force-update-confirm-password" placeholder="Confirm new password" required>
+        </div>
+        <p class="force-update-new-password-error text-danger text-center hidden">Passwords don't match.</p>
+        <div class="login-button-holder">
+          <button type="submit" class="btn btn-primary btn-force-update-pass">Update password</button>
+          <button type="button" class="btn btn-link btn-force-update-cancel">Cancel</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/js/build.js
+++ b/js/build.js
@@ -76,14 +76,20 @@ $('[data-login-id]').each(function() {
 
       var user = createUserProfile(response);
 
-      return updateUserData({
-        id: response.id,
-        region: response.region,
-        userRoleId: response.userRoleId,
-        authToken: response.auth_token,
-        email: response.email,
-        legacy: response.legacy
-      });
+      return Promise.all([
+        updateUserData({
+          id: response.id,
+          region: response.region,
+          userRoleId: response.userRoleId,
+          authToken: response.auth_token,
+          email: response.email,
+          legacy: response.legacy
+        }),
+        Fliplet.Profile.set({
+          email: response.email,
+          user: user
+        })
+      ]);
     }).then(function() {
       _this.$container.find('.btn-login').removeClass('disabled');
       _this.$container.find('.btn-login').html(LABELS.loginDefault);

--- a/js/build.js
+++ b/js/build.js
@@ -309,7 +309,7 @@ $('[data-login-id]').each(function() {
       promises.push(Fliplet.Native.Authentication.saveUserDetails(data));
     }
 
-    return promises;
+    return Promise.all(promises);
   }
 
   function init() {

--- a/js/build.js
+++ b/js/build.js
@@ -81,7 +81,8 @@ $('[data-login-id]').each(function() {
         region: response.region,
         userRoleId: response.userRoleId,
         authToken: response.auth_token,
-        email: response.email
+        email: response.email,
+        legacy: response.legacy
       });
     }).then(function() {
       _this.$container.find('.btn-login').removeClass('disabled');
@@ -257,7 +258,8 @@ $('[data-login-id]').each(function() {
         region: userData.region,
         userRoleId: userData.userRoleId,
         authToken: userData.auth_token,
-        email: userData.email
+        email: userData.email,
+        legacy: userData.legacy
       });
     }).then(function() {
       _this.$container.find('.two-factor-btn').removeClass('disabled');
@@ -291,7 +293,7 @@ $('[data-login-id]').each(function() {
       id: data.id
     });
 
-    return Promise.all([
+    var promises = [
       Fliplet.App.Storage.set(_this.pvNameStorage, {
         userRoleId: data.userRoleId,
         auth_token: data.authToken,
@@ -301,7 +303,13 @@ $('[data-login-id]').each(function() {
         email: data.email,
         user: user
       })
-    ]);
+    ];
+
+    if (Fliplet.Env.is('native')) {
+      promises.push(Fliplet.Native.Authentication.saveUserDetails(data));
+    }
+
+    return promises;
   }
 
   function init() {
@@ -318,7 +326,8 @@ $('[data-login-id]').each(function() {
           region: session.auth_token.substr(0, 2),
           userRoleId: session.user.userRoleId,
           authToken: session.auth_token,
-          email: session.user.email
+          email: session.user.email,
+          legacy: session.legacy
         });
       })
       .then(function () {
@@ -334,7 +343,8 @@ $('[data-login-id]').each(function() {
               region: response.region,
               userRoleId: response.user.userRoleId,
               authToken: response.user.auth_token,
-              email: response.user.email
+              email: response.user.email,
+              legacy: session.legacy
             });
           });
       })

--- a/js/build.js
+++ b/js/build.js
@@ -344,7 +344,7 @@ $('[data-login-id]').each(function() {
               userRoleId: response.user.userRoleId,
               authToken: response.user.auth_token,
               email: response.user.email,
-              legacy: session.legacy
+              legacy: response.user.legacy
             });
           });
       })


### PR DESCRIPTION
...for v1 apps opened in Fliplet Viewer to check for updates

### To be completed

- [x] Updated logout code in app-list and custom code to reset native storage
- [x] Confirm sessions successfully return legacy user data
- [x] Confirm `createUserProfile()` works as expected