### PR TITLE
Makes sure widget loads in edit mode

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -356,7 +356,7 @@ $('[data-login-id]').each(function() {
     setTimeout(function(){
       var $loginHolder = _this.$container.find('.login-loader-holder');
       $loginHolder.fadeOut(100, function() {
-        $loginHolder.fadeIn(300);
+        _this.$container.find('.content-wrapper').show();
         calculateElHeight($('.state.start'));
       });
     }, 100);
@@ -425,6 +425,10 @@ $('[data-login-id]').each(function() {
       .then(function () {
         if (Fliplet.Env.get('disableSecurity')) {
           return Promise.reject('Login verified. Redirection is disabled when security isn\'t enabled.');
+        }
+
+        if (Fliplet.Env.get('interact')) {
+          return Promise.reject('Login verified. Redirection is disabled when editing screens.');
         }
 
         var navigate = Fliplet.Navigate.to(_this.data.action);


### PR DESCRIPTION
Show widget's starting state if verified in edit mode.

Prevents the widget being stuck in loading mode when editing (see below).

![image](https://user-images.githubusercontent.com/290733/44089590-42e49efa-9fbf-11e8-8069-ed524c7b6827.png)
