### PR TITLE
Clicking on "Need help" now leads to Fliplet documentation about Login components 

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -2,7 +2,7 @@
   <form class="form-horizontal">
     <header>
       <p>Configure your login component</p>
-      <a id="help_tip" href="#">Need help?</a>
+      <a href="https://help.fliplet.com/article/181-login-components">Need help?</a>
     </header>
     <div class="form-group">
         <div class="col-sm-4 control-label">

--- a/js/interface.js
+++ b/js/interface.js
@@ -50,7 +50,3 @@ function save(notifyComplete) {
 $('#login_heading').on('keyup change paste blur', $.debounce(function() {
   save();
 }, 500));
-
-$('#help_tip').on('click', function() {
-  alert("During beta, please use live chat and let us know what you need help with.");
-});


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4959

Description
Added link on "Need help" button. Removed not needed function.

Backward compatibility
This change is fully backward compatible.