### PR TITLE
don't overwrite the app's token when logging in

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -380,10 +380,6 @@ $('[data-login-id]').each(function() {
       })
     ];
 
-    if (Fliplet.Env.is('native')) {
-      promises.push(Fliplet.Native.Authentication.saveUserDetails(data));
-    }
-
     return Promise.all(promises);
   }
 


### PR DESCRIPTION
- To confirm changes required in portal component to still allow impersonating users