### PR TITLE
DEV-637 [Fix] Ensures app stores fliplet user details instead of app token

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -549,6 +549,7 @@ Fliplet.Widget.instance('login', function(data) {
             legacy: session.legacy
           };
 
+          // If passport found, then store details from there
           if (session && session.server &&
               session.server.passports &&
               session.server.passports.flipletLogin &&

--- a/js/build.js
+++ b/js/build.js
@@ -540,15 +540,28 @@ Fliplet.Widget.instance('login', function(data) {
             return Promise.reject(T('widgets.login.fliplet.errors.sessionNotFound'));
           }
 
-          // Update stored email address based on retrieved session
-          return Fliplet.Login.updateUserStorage({
+          let updatedUser = {
             id: session.user.id,
             region: session.auth_token.substr(0, 2),
             userRoleId: session.user.userRoleId,
             authToken: session.user.auth_token,
             email: session.user.email,
             legacy: session.legacy
-          });
+          };
+
+          if (session && session.server &&
+              session.server.passports &&
+              session.server.passports.flipletLogin &&
+              session.server.passports.flipletLogin.length) {
+            const flLoginUser = session.server.passports.flipletLogin[0];
+            updatedUser.email = flLoginUser.email || updatedUser.email;
+            updatedUser.authToken = flLoginUser.auth_token || updatedUser.authToken;
+            updatedUser.region = flLoginUser.region || updatedUser.region;
+            updatedUser.userRoleId = flLoginUser.userRoleId || updatedUser.userRoleId;
+          }
+
+          // Update stored email address based on retrieved session
+          return Fliplet.Login.updateUserStorage(updatedUser);
         })
         .then(function() {
           if (!Fliplet.Navigator.isOnline()) {

--- a/js/build.js
+++ b/js/build.js
@@ -554,11 +554,15 @@ Fliplet.Widget.instance('login', function(data) {
               session.server.passports &&
               session.server.passports.flipletLogin &&
               session.server.passports.flipletLogin.length) {
-            const flLoginUser = session.server.passports.flipletLogin[0];
-            updatedUser.email = flLoginUser.email || updatedUser.email;
-            updatedUser.authToken = flLoginUser.auth_token || updatedUser.authToken;
-            updatedUser.region = flLoginUser.region || updatedUser.region;
-            updatedUser.userRoleId = flLoginUser.userRoleId || updatedUser.userRoleId;
+            const flLoginUser = session.server.passports.flipletLogin[0] || {};
+
+            updatedUser = {
+              ...updatedUser,
+              email: flLoginUser.email || updatedUser.email,
+              authToken: flLoginUser.auth_token || updatedUser.authToken,
+              region: flLoginUser.region || updatedUser.region,
+              userRoleId: flLoginUser.userRoleId || updatedUser.userRoleId
+            };
           }
 
           // Update stored email address based on retrieved session


### PR DESCRIPTION
### What does this PR do?
This PR ensures that app storage always store fliplet studio user credential details (email, role id, auth_token, region) instead of storing app token's details. This way organization can be switched without any issues.

### JIRA Ticket
[DEV-637](https://weboo.atlassian.net/browse/DEV-637)

[DEV-637]: https://weboo.atlassian.net/browse/DEV-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ