### PR TITLE
DEV-983 [Feat] Restrict Dev Environment Dashboard access to Fliplet Admins

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3,8 +3,17 @@
 
   Fliplet.Login = (function() {
     var ORG_ADMIN_ROLE_ID = 1;
+    var FLIPLET_ADMIN_ROLE_ID = 1;
     var storageName = 'fliplet_login_component';
     var skipSetupStorageName = 'skipFlipletAccountSetup';
+
+    // Master app and production app IDs for the deployed Dev Environment Dashboards.
+    // Kept in sync with the map in js/build.js — update both when adding a new env.
+    var DEV_ENVIRONMENT_APPS = {
+      'https://env.fliplet.com/': [436446, 436447],
+      'https://staging-apps.fliplet.com/': [511849, 511850],
+      'https://apps.fliplet.test/': [11, 12]
+    };
 
     /**
      * Creates user profile data
@@ -90,6 +99,28 @@
 
           return response;
         });
+      });
+    }
+
+    /**
+     * Verify that the given user is allowed to access the current app when it
+     * is a Dev Environment Dashboard (Fliplet Admins only). Logs the user out
+     * and rejects on failure; resolves silently otherwise.
+     * @param {Object} user - User object exposing userRoleId
+     * @returns {Promise} Resolves if allowed, rejects with i18n error if not
+     */
+    function verifyUserForDevEnvApp(user) {
+      var allowedAppIds = DEV_ENVIRONMENT_APPS[Fliplet.Env.get('appsUrl')];
+      var isDevEnvApp = Array.isArray(allowedAppIds)
+        && allowedAppIds.indexOf(Fliplet.Env.get('appId')) !== -1;
+
+      if (!isDevEnvApp || !user || user.userRoleId === FLIPLET_ADMIN_ROLE_ID) {
+        return Promise.resolve();
+      }
+
+      // Tear down the session so the user isn't left authenticated-but-blocked
+      return Fliplet.Session.logout().catch(function() {}).then(function() {
+        return Promise.reject(T('widgets.login.fliplet.errors.userNotAFlipletAdmin'));
       });
     }
 
@@ -195,6 +226,10 @@
       }
 
       return getData.then(function(response) {
+        return verifyUserForDevEnvApp(_.get(response, 'user')).then(function() {
+          return response;
+        });
+      }).then(function(response) {
         return userMustSetupAccount(response).then(function(setupRequired) {
           if (setupRequired) {
             return goToAccountSetup();
@@ -217,6 +252,7 @@
     return {
       updateUserStorage: updateUserStorage,
       validateAccount: validateAccount,
+      verifyUserForDevEnvApp: verifyUserForDevEnvApp,
       setSkipSetupStorage: setSkipSetupStorage
     };
   }());

--- a/js/app.js
+++ b/js/app.js
@@ -8,7 +8,6 @@
     var skipSetupStorageName = 'skipFlipletAccountSetup';
 
     // Master app and production app IDs for the deployed Dev Environment Dashboards.
-    // Kept in sync with the map in js/build.js — update both when adding a new env.
     var DEV_ENVIRONMENT_APPS = {
       'https://env.fliplet.com/': [436446, 436447],
       'https://staging-apps.fliplet.com/': [511849, 511850],

--- a/js/app.js
+++ b/js/app.js
@@ -2,8 +2,8 @@
   var Fliplet = window.Fliplet || {};
 
   Fliplet.Login = (function() {
-    var ORG_ADMIN_ROLE_ID = 1;
-    var FLIPLET_ADMIN_ROLE_ID = 1;
+    var ORG_ADMIN_ROLE_ID = 1; // This role ID is assigned to Fliplet Studio user who is an organization admin
+    var FLIPLET_ADMIN_ROLE_ID = 1; // This is user role ID which is only assigned to Fliplet Staff
     var storageName = 'fliplet_login_component';
     var skipSetupStorageName = 'skipFlipletAccountSetup';
 
@@ -121,7 +121,11 @@
       return Fliplet.Session.logout().catch(function(err) {
         console.warn('[verifyUserForDevEnvApp] Failed to log out blocked user:', err);
       }).then(function() {
-        return Promise.reject(T('widgets.login.fliplet.errors.userNotAFlipletAdmin'));
+        var error = new Error(T('widgets.login.fliplet.errors.userNotAFlipletAdmin'));
+
+        error.code = 'USER_NOT_FLIPLET_ADMIN';
+
+        return Promise.reject(error);
       });
     }
 
@@ -264,7 +268,15 @@
     key: cacheKey,
     expire: 60 * 60 * 12 // Keep cache for half a day
   }, function onFetchData() {
-    return Fliplet.Login.validateAccount();
+    return Fliplet.Login.validateAccount().catch(function(error) {
+      // Surface the admin-gate rejection to the user on boot — unlike the
+      // login-time paths, this one has no UI handler upstream.
+      if (error && error.code === 'USER_NOT_FLIPLET_ADMIN') {
+        Fliplet.UI.Toast.error(error, { message: error.message });
+      }
+
+      return Promise.reject(error);
+    });
   });
 
   Fliplet.Hooks.on('login', function(data) {

--- a/js/app.js
+++ b/js/app.js
@@ -121,6 +121,18 @@
       return Fliplet.Session.logout().catch(function(err) {
         console.warn('[verifyUserForDevEnvApp] Failed to log out blocked user:', err);
       }).then(function() {
+        // Belt-and-suspenders: clear local client state even if the server
+        // logout failed, so no partially-authenticated footprint remains for
+        // other widgets (Fliplet.Profile, app storage) to read.
+        return Promise.all([
+          Fliplet.App.Storage.remove(storageName).catch(function(err) {
+            console.warn('[verifyUserForDevEnvApp] Failed to clear app storage:', err);
+          }),
+          Fliplet.Profile.remove(['email', 'user']).catch(function(err) {
+            console.warn('[verifyUserForDevEnvApp] Failed to clear profile:', err);
+          })
+        ]);
+      }).then(function() {
         var error = new Error(T('widgets.login.fliplet.errors.userNotAFlipletAdmin'));
 
         error.code = 'USER_NOT_FLIPLET_ADMIN';

--- a/js/app.js
+++ b/js/app.js
@@ -118,7 +118,9 @@
       }
 
       // Tear down the session so the user isn't left authenticated-but-blocked
-      return Fliplet.Session.logout().catch(function() {}).then(function() {
+      return Fliplet.Session.logout().catch(function(err) {
+        console.warn('[verifyUserForDevEnvApp] Failed to log out blocked user:', err);
+      }).then(function() {
         return Promise.reject(T('widgets.login.fliplet.errors.userNotAFlipletAdmin'));
       });
     }

--- a/js/build.js
+++ b/js/build.js
@@ -153,14 +153,16 @@ Fliplet.Widget.instance('login', function(data) {
                       return reject(T('widgets.login.fliplet.errors.loginNotFinished'));
                     }
 
-                    // Update stored email address based on retrieved session
-                    Fliplet.Login.updateUserStorage({
-                      id: session.user.id,
-                      region: session.auth_token.substr(0, 2),
-                      userRoleId: session.user.userRoleId,
-                      authToken: user.auth_token,
-                      email: session.user.email,
-                      legacy: session.legacy
+                    return Fliplet.Login.verifyUserForDevEnvApp(user).then(function() {
+                      // Update stored email address based on retrieved session
+                      return Fliplet.Login.updateUserStorage({
+                        id: session.user.id,
+                        region: session.auth_token.substr(0, 2),
+                        userRoleId: session.user.userRoleId,
+                        authToken: user.auth_token,
+                        email: session.user.email,
+                        legacy: session.legacy
+                      });
                     }).then(function() {
                       return Fliplet.Hooks.run('login', {
                         passport: 'fliplet',
@@ -168,7 +170,7 @@ Fliplet.Widget.instance('login', function(data) {
                       });
                     }).then(function() {
                       return Fliplet.Login.validateAccount().then(resolve).catch(reject);
-                    });
+                    }).catch(reject);
                   });
                 }
               }).then(function() {
@@ -623,18 +625,20 @@ Fliplet.Widget.instance('login', function(data) {
           return Promise.reject('Login failed. Please try again later.');
         }
 
-        Fliplet.Storage.set(LOGIN_FLAG_KEY, true);
+        return Fliplet.Login.verifyUserForDevEnvApp(user).then(function() {
+          Fliplet.Storage.set(LOGIN_FLAG_KEY, true);
 
-        // Add organization data to response
-        return Fliplet.API.request({
-          url: 'v1/organizations',
-          headers: {
-            'Auth-token': user.auth_token
-          }
-        }).then(function(data) {
-          _.set(response, 'userOrganizations', _.get(data, 'organizations', []));
+          // Add organization data to response
+          return Fliplet.API.request({
+            url: 'v1/organizations',
+            headers: {
+              'Auth-token': user.auth_token
+            }
+          }).then(function(data) {
+            _.set(response, 'userOrganizations', _.get(data, 'organizations', []));
 
-          return response;
+            return response;
+          });
         });
       });
     }

--- a/js/build.js
+++ b/js/build.js
@@ -153,7 +153,7 @@ Fliplet.Widget.instance('login', function(data) {
                       return reject(T('widgets.login.fliplet.errors.loginNotFinished'));
                     }
 
-                    return Fliplet.Login.verifyUserForDevEnvApp(user).then(function() {
+                    return Fliplet.Login.verifyUserForDevEnvApp(session.user).then(function() {
                       // Update stored email address based on retrieved session
                       return Fliplet.Login.updateUserStorage({
                         id: session.user.id,

--- a/translation.json
+++ b/translation.json
@@ -91,7 +91,8 @@
           "loginNotFinished": "You didn't finish the login process.",
           "loginFailed": "Login failed. Please try again later.",
           "sessionNotFound": "Login session not found",
-          "unableLogin": "Unable to login. Try again later."
+          "unableLogin": "Unable to login. Try again later.",
+          "userNotAFlipletAdmin": "Only Fliplet Admins can access this app."
         },
         "warnings": {
           "noRedirectWithoutSecurity": "Login verified. Redirection is disabled when security isn't enabled.",


### PR DESCRIPTION
## Summary
- Adds `Fliplet.Login.verifyUserForDevEnvApp(user)` in `js/app.js` — logs the user out and rejects with an i18n error when the current app is a known Dev Environment Dashboard but the user's `userRoleId !== 1` (Fliplet Admin). Resolves silently otherwise.
- Invokes the check from both login paths in `js/build.js` (SSO `onclose` and the password-based `login()` flow) so authentication actually halts on failure (earlier version called an undefined `reject` and didn't `return` the promise).
- Invokes the check inside `validateAccount` in `js/app.js` so returning sessions are also enforced on app boot (validateAccount runs via `Fliplet.Cache.get` every 12h), not only at login time.
- Adds translation key `widgets.login.fliplet.errors.userNotAFlipletAdmin`.

## Why
The Dev Environment Dashboard web app uses this shared Fliplet login widget. The `/v1/dev-envs` API is already admin-gated server-side (`router.use(devEnvironment.authenticateAdminWithFlipletLogin)`), but without a client-side check a non-admin could still complete login and land in a broken dashboard UI. This closes the UX gap.

## Notes / follow-ups
- `DEV_ENVIRONMENT_APPS` is hardcoded (master + production app IDs per environment URL). Adding a future dev-env deployment requires updating this map and cutting a widget release. A widget-data-driven `requireFlipletAdmin` flag would be cleaner — happy to follow up in a separate ticket.
- Please double-check the `https://apps.fliplet.test/` host is the correct URL for that environment.

## Test plan
- [ ] Log in as a Fliplet Admin (`userRoleId === 1`) on the Dev Env Dashboard app — access granted.
- [ ] Log in as a non-admin on the Dev Env Dashboard app — toast shows "Only Fliplet Admins can access this app.", session is logged out.
- [ ] Repeat for the SSO login path.
- [ ] Log in as a non-admin on a non-dev-env app — unaffected, logs in normally.
- [ ] Returning session: non-admin with an existing session reopens the Dev Env Dashboard app — blocked on boot via `validateAccount`.
- [ ] Translation renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)