### PR TITLE
DEV-983 [Feat] Restrict Dev Environment Dashboard access to Fliplet Admins (#92)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,9 +2,17 @@
   var Fliplet = window.Fliplet || {};
 
   Fliplet.Login = (function() {
-    var ORG_ADMIN_ROLE_ID = 1;
+    var ORG_ADMIN_ROLE_ID = 1; // This role ID is assigned to Fliplet Studio user who is an organization admin
+    var FLIPLET_ADMIN_ROLE_ID = 1; // This is user role ID which is only assigned to Fliplet Staff
     var storageName = 'fliplet_login_component';
     var skipSetupStorageName = 'skipFlipletAccountSetup';
+
+    // Master app and production app IDs for the deployed Dev Environment Dashboards.
+    var DEV_ENVIRONMENT_APPS = {
+      'https://env.fliplet.com/': [436446, 436447],
+      'https://staging-apps.fliplet.com/': [511849, 511850],
+      'https://apps.fliplet.test/': [11, 12]
+    };
 
     /**
      * Creates user profile data
@@ -90,6 +98,46 @@
 
           return response;
         });
+      });
+    }
+
+    /**
+     * Verify that the given user is allowed to access the current app when it
+     * is a Dev Environment Dashboard (Fliplet Admins only). Logs the user out
+     * and rejects on failure; resolves silently otherwise.
+     * @param {Object} user - User object exposing userRoleId
+     * @returns {Promise} Resolves if allowed, rejects with i18n error if not
+     */
+    function verifyUserForDevEnvApp(user) {
+      var allowedAppIds = DEV_ENVIRONMENT_APPS[Fliplet.Env.get('appsUrl')];
+      var isDevEnvApp = Array.isArray(allowedAppIds)
+        && allowedAppIds.indexOf(Fliplet.Env.get('appId')) !== -1;
+
+      if (!isDevEnvApp || !user || user.userRoleId === FLIPLET_ADMIN_ROLE_ID) {
+        return Promise.resolve();
+      }
+
+      // Tear down the session so the user isn't left authenticated-but-blocked
+      return Fliplet.Session.logout().catch(function(err) {
+        console.warn('[verifyUserForDevEnvApp] Failed to log out blocked user:', err);
+      }).then(function() {
+        // Belt-and-suspenders: clear local client state even if the server
+        // logout failed, so no partially-authenticated footprint remains for
+        // other widgets (Fliplet.Profile, app storage) to read.
+        return Promise.all([
+          Fliplet.App.Storage.remove(storageName).catch(function(err) {
+            console.warn('[verifyUserForDevEnvApp] Failed to clear app storage:', err);
+          }),
+          Fliplet.Profile.remove(['email', 'user']).catch(function(err) {
+            console.warn('[verifyUserForDevEnvApp] Failed to clear profile:', err);
+          })
+        ]);
+      }).then(function() {
+        var error = new Error(T('widgets.login.fliplet.errors.userNotAFlipletAdmin'));
+
+        error.code = 'USER_NOT_FLIPLET_ADMIN';
+
+        return Promise.reject(error);
       });
     }
 
@@ -195,6 +243,10 @@
       }
 
       return getData.then(function(response) {
+        return verifyUserForDevEnvApp(_.get(response, 'user')).then(function() {
+          return response;
+        });
+      }).then(function(response) {
         return userMustSetupAccount(response).then(function(setupRequired) {
           if (setupRequired) {
             return goToAccountSetup();
@@ -217,6 +269,7 @@
     return {
       updateUserStorage: updateUserStorage,
       validateAccount: validateAccount,
+      verifyUserForDevEnvApp: verifyUserForDevEnvApp,
       setSkipSetupStorage: setSkipSetupStorage
     };
   }());
@@ -227,7 +280,15 @@
     key: cacheKey,
     expire: 60 * 60 * 12 // Keep cache for half a day
   }, function onFetchData() {
-    return Fliplet.Login.validateAccount();
+    return Fliplet.Login.validateAccount().catch(function(error) {
+      // Surface the admin-gate rejection to the user on boot — unlike the
+      // login-time paths, this one has no UI handler upstream.
+      if (error && error.code === 'USER_NOT_FLIPLET_ADMIN') {
+        Fliplet.UI.Toast.error(error, { message: error.message });
+      }
+
+      return Promise.reject(error);
+    });
   });
 
   Fliplet.Hooks.on('login', function(data) {

--- a/js/build.js
+++ b/js/build.js
@@ -153,14 +153,16 @@ Fliplet.Widget.instance('login', function(data) {
                       return reject(T('widgets.login.fliplet.errors.loginNotFinished'));
                     }
 
-                    // Update stored email address based on retrieved session
-                    Fliplet.Login.updateUserStorage({
-                      id: session.user.id,
-                      region: session.auth_token.substr(0, 2),
-                      userRoleId: session.user.userRoleId,
-                      authToken: user.auth_token,
-                      email: session.user.email,
-                      legacy: session.legacy
+                    return Fliplet.Login.verifyUserForDevEnvApp(session.user).then(function() {
+                      // Update stored email address based on retrieved session
+                      return Fliplet.Login.updateUserStorage({
+                        id: session.user.id,
+                        region: session.auth_token.substr(0, 2),
+                        userRoleId: session.user.userRoleId,
+                        authToken: user.auth_token,
+                        email: session.user.email,
+                        legacy: session.legacy
+                      });
                     }).then(function() {
                       return Fliplet.Hooks.run('login', {
                         passport: 'fliplet',
@@ -168,7 +170,7 @@ Fliplet.Widget.instance('login', function(data) {
                       });
                     }).then(function() {
                       return Fliplet.Login.validateAccount().then(resolve).catch(reject);
-                    });
+                    }).catch(reject);
                   });
                 }
               }).then(function() {
@@ -623,18 +625,20 @@ Fliplet.Widget.instance('login', function(data) {
           return Promise.reject('Login failed. Please try again later.');
         }
 
-        Fliplet.Storage.set(LOGIN_FLAG_KEY, true);
+        return Fliplet.Login.verifyUserForDevEnvApp(user).then(function() {
+          Fliplet.Storage.set(LOGIN_FLAG_KEY, true);
 
-        // Add organization data to response
-        return Fliplet.API.request({
-          url: 'v1/organizations',
-          headers: {
-            'Auth-token': user.auth_token
-          }
-        }).then(function(data) {
-          _.set(response, 'userOrganizations', _.get(data, 'organizations', []));
+          // Add organization data to response
+          return Fliplet.API.request({
+            url: 'v1/organizations',
+            headers: {
+              'Auth-token': user.auth_token
+            }
+          }).then(function(data) {
+            _.set(response, 'userOrganizations', _.get(data, 'organizations', []));
 
-          return response;
+            return response;
+          });
         });
       });
     }

--- a/translation.json
+++ b/translation.json
@@ -91,7 +91,8 @@
           "loginNotFinished": "You didn't finish the login process.",
           "loginFailed": "Login failed. Please try again later.",
           "sessionNotFound": "Login session not found",
-          "unableLogin": "Unable to login. Try again later."
+          "unableLogin": "Unable to login. Try again later.",
+          "userNotAFlipletAdmin": "Only Fliplet Admins can access this app."
         },
         "warnings": {
           "noRedirectWithoutSecurity": "Login verified. Redirection is disabled when security isn't enabled.",


### PR DESCRIPTION
* DEV-983 [Feat] Restrict Dev Environment Dashboard access to Fliplet Admins

Adds Fliplet.Login.verifyUserForDevEnvApp which rejects and logs out any user whose userRoleId is not 1 when the current app is a known Dev Environment Dashboard. Invoked from both login paths in build.js and from validateAccount in app.js so returning sessions are also enforced.



* DEV-983 [Fix] Address PR review — pass session.user to admin gate

- SSO onclose path now passes session.user to verifyUserForDevEnvApp so the userRoleId check lines up with how session.user is read elsewhere in the same block. The raw passport object is not a reliable carrier of userRoleId and was rejecting valid admins via SSO.
- Drop the stale "kept in sync with js/build.js" comment; after the refactor the DEV_ENVIRONMENT_APPS map only lives in app.js.



* DEV-983 [Chore] Warn on logout failure in dev-env admin gate

Replaces the silent .catch with console.warn so a stuck authenticated-but-blocked state is diagnosable in the console rather than invisible.



* DEV-983 [Fix] Surface admin-gate rejection on app boot

Fliplet.Cache.get in app.js runs validateAccount on every app boot, but had no .catch — so a returning non-admin session was logged out silently with no UI feedback. Tag the rejection with code=USER_NOT_FLIPLET_ADMIN so the boot path can toast it without hijacking unrelated rejections.



* DEV-983 [Fix] Clear local client state even on logout failure

Belt-and-suspenders cleanup so a blocked non-admin user isn't left with a partially authenticated footprint (app storage, Fliplet.Profile) if the server-side Fliplet.Session.logout() fails. Each clear is best- effort with its own console.warn fallback.



---------