### PR TITLE
fix(login): also listen to IAB loadstop for Android same-origin redirects

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -274,8 +274,10 @@ Fliplet.Widget.instance('login', function(data) {
     var options = 'location=no,enableViewportScale=yes,toolbarposition=top,fullscreen=yes';
     var browser = window.cordova.InAppBrowser.open(loginUrl, '_blank', options);
 
-    function onLoadStart(event) {
+    function tryHandle(event, source) {
       if (!event || !event.url || iabHandled) return;
+      console.log('[Fliplet.Login][IAB ' + source + ']', event.url);
+
       if (event.url.indexOf(callbackPrefix) !== 0) return;
 
       var qs = parseQueryString(event.url);
@@ -301,8 +303,25 @@ Fliplet.Widget.instance('login', function(data) {
       handleAuthSuccess({ token: qs.token, user: user });
     }
 
+    function onLoadStart(event) {
+      tryHandle(event, 'loadstart');
+    }
+
+    function onLoadStop(event) {
+      // Android WebView doesn't always fire `shouldOverrideUrlLoading`
+      // for same-origin `location.href` redirects, so `loadstart` can
+      // miss the final callback URL hop on Android (the API renders
+      // its /v1/auth/return-token fallback page and the user gets
+      // stranded). `loadstop` fires reliably on every navigation
+      // completion on both platforms — it's the safety net. Both
+      // listeners short-circuit via `iabHandled` so we only run the
+      // success path once.
+      tryHandle(event, 'loadstop');
+    }
+
     function onExit() {
       browser.removeEventListener('loadstart', onLoadStart);
+      browser.removeEventListener('loadstop', onLoadStop);
       browser.removeEventListener('exit', onExit);
 
       // Only reset the button if the user closed the IAB before
@@ -314,6 +333,7 @@ Fliplet.Widget.instance('login', function(data) {
     }
 
     browser.addEventListener('loadstart', onLoadStart);
+    browser.addEventListener('loadstop', onLoadStop);
     browser.addEventListener('exit', onExit);
   }
 


### PR DESCRIPTION
## Summary

QA reported that on **Android**, the post-login redirect doesn't happen for any login type (email/password or SSO) — the user submits credentials, the API processes successfully, but the IAB stays on the static "Sign-in complete" fallback page and has to be closed manually. On **iOS physical devices** the same symptom appears for SSO logins (email/password works on Simulator but not always on real devices).

## Root cause

Cordova-plugin-inappbrowser on Android wires its \`loadstart\` event to Android WebView's \`shouldOverrideUrlLoading()\` hook. WebView optimises **same-origin** \`location.href = newUrl\` redirects by handling them internally without invoking that hook — so \`loadstart\` doesn't fire for the api.fliplet.com → api.fliplet.com/v1/auth/return-token hop that the auth-loader / autoSuccess script does on success.

Real iOS devices have a similar quirk in WKWebView for client-side redirects after complex cross-domain chains (the SSO round-trip), while the Simulator's macOS WebKit handles it differently and fires \`loadstart\` as expected.

Either way, our callback intercept in \`openSignInIAB\` was only attached to \`loadstart\` — so when that didn't fire, the IAB never closed and \`handleAuthSuccess\` never ran.

## Fix

Subscribe to \`loadstop\` in addition to \`loadstart\`. \`loadstop\` fires reliably on every navigation completion on both platforms, regardless of how the WebView optimised the route. A shared \`tryHandle()\` helper runs the URL match + token extraction; \`iabHandled\` de-dupes so the success path runs exactly once even when both events fire.

\`loadstart\` is kept for the fast intercept path on iOS Simulator (and Android where it does fire), so we don't pay the cost of waiting for the API's fallback page to paint when we don't have to.

A single \`console.log\` per event is kept temporarily for QA diagnostics — easy to strip once both platforms are confirmed.

## Test plan

- [ ] **Android** physical device: tap Sign in → email/password → IAB closes automatically → user is redirected to configured next page
- [ ] **Android** physical device: tap Sign in → Apple/Microsoft SSO → IAB closes automatically → user redirected
- [ ] **iOS** physical device (the gap from PR #96 fix that QA flagged): tap Sign in → email/password → user redirected
- [ ] **iOS** physical device: tap Sign in → Apple/Microsoft SSO → user redirected (Google still blocked separately — \`disallowed_useragent\`)
- [ ] **iOS Simulator** regression: previously-working email/password still redirects (loadstart path still fires)
- [ ] **Web** regression: not touched by this change but worth a smoke test

## Known limitation

Google SSO continues to fail on native with \`Error 403: disallowed_useragent\` — Google's policy block on OAuth from embedded WebViews. Out of scope for this fix; needs a separate change (system browser / SFSafariViewController + custom URL scheme callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)