### PR TITLE
DEV-1633: redeem authState on its issuing host + validate authHost

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "fliplet",
   "overrides": [
     {
-      "comment": "test/ runs under node --test, never in a browser, so it is not bound by the ES5 level the shipped widget assets target. js/ is unaffected by this override.",
       "files": ["test/**/*.js"],
       "parserOptions": {
         "ecmaVersion": 2022,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,17 @@
 {
-  "extends": "fliplet"
+  "extends": "fliplet",
+  "overrides": [
+    {
+      "comment": "test/ runs under node --test, never in a browser, so it is not bound by the ES5 level the shipped widget assets target. js/ is unaffected by this override.",
+      "files": ["test/**/*.js"],
+      "parserOptions": {
+        "ecmaVersion": 2022,
+        "sourceType": "script"
+      },
+      "env": {
+        "node": true,
+        "es2022": true
+      }
+    }
+  ]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+# The widget's only automated check. safe-auth-host.js is the allowlist that
+# decides where the sign-in exchange sends its credential, and the absence of
+# that control is what caused the DEV-1572 revert — so its tests should not
+# depend on someone remembering to run npm test.
+#
+# node --test is built in: no dependency install, nothing to keep in sync.
+name: Test
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run tests
+        run: npm test
+
+      - name: Syntax-check the shipped widget assets
+        # These load in a browser, never in Node, so they are not covered by
+        # the test run above. --check is the cheapest guard against a parse
+        # error reaching a published app.
+        run: |
+          for f in js/*.js; do
+            node --check "$f"
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,11 @@
 name: Test
 
 on:
+  # pull_request covers every branch that matters while it is under review.
+  # Limiting push to the long-lived branches avoids running the same commit
+  # twice on every PR push, which `branches: ['**']` here did.
   push:
-    branches: ['**']
+    branches: [master, production]
   pull_request:
 
 jobs:

--- a/js/build.js
+++ b/js/build.js
@@ -490,8 +490,11 @@ Fliplet.Widget.instance('login', function(data) {
       xhr.onload = function() {
         var session;
 
+        var response;
+
         try {
-          session = JSON.parse(xhr.responseText).session;
+          response = JSON.parse(xhr.responseText);
+          session = response.session;
         } catch (err) {
           return fail('response was not JSON', xhr.status);
         }
@@ -500,16 +503,20 @@ Fliplet.Widget.instance('login', function(data) {
           return fail('unexpected response shape', xhr.status);
         }
 
-        // Pass the user through whole rather than hand-picking fields — the
-        // earlier six-field copy dropped data for deployed web/native sign-ins
-        // only. Note this is the session's user (models/session.js getPublic(),
-        // which omits auth_token); it is NOT identical to the profile the
-        // legacy token+user contract carries, which the login route enriches
-        // with host/region/organization/isFirstLogin/mustVerifyEmail and setup
-        // status. Public `login` hook consumers therefore still see a smaller
-        // object on this path — normalising the two shapes needs its own
-        // decision, since narrowing the legacy one would break consumers.
-        resolve({ token: session.auth_token, user: session.user });
+        // Prefer the enriched profile the API builds for a state redemption
+        // (host, region, organization, policy, setup status, isFirstLogin,
+        // mustVerifyEmail), so Fliplet.Hooks.run('login') gets the same shape
+        // the legacy token+user contract carried. It is built server-side from
+        // the authenticated user, not echoed back from the mint.
+        //
+        // Falls back to the session's user when absent — an API predating
+        // DEV-1633's profile support, or a profile build that failed and was
+        // logged server-side. Sign-in still completes; the hook payload is
+        // just the smaller object.
+        resolve({
+          token: session.auth_token,
+          user: response.profile || session.user
+        });
       };
 
       xhr.onerror = function() {

--- a/js/build.js
+++ b/js/build.js
@@ -416,12 +416,18 @@ Fliplet.Widget.instance('login', function(data) {
     // options.apiUrl replaces the base instead, which is the supported retarget
     // (added in DEV-667). Cores predating it ignore the option and fall back to
     // the app's own host — same-region behaviour, not a broken request.
-    var opts = { url: 'v1/session?state=' + encodeURIComponent(authState) };
-    var safeHost = safeAuthHost(authHost);
-
-    if (safeHost) {
-      opts.apiUrl = safeHost;
-    }
+    //
+    // apiUrl is set unconditionally. Leaving it off does NOT fall back to the
+    // canonical API host: Fliplet.API.request's default base is
+    // Fliplet.Env.get('apiUrl'), which inside a published web app is the
+    // apps-host-proxied URL (https://apps.fliplet.com/) rather than the API
+    // host — the same distinction getApiHost() exists to paper over. Pinning it
+    // to getApiOrigin() keeps the exchange on the host that serves these routes
+    // and matches where the login URL itself was sent.
+    var opts = {
+      url: 'v1/session?state=' + encodeURIComponent(authState),
+      apiUrl: safeAuthHost(authHost) || getApiOrigin()
+    };
 
     return Fliplet.API.request(opts).then(function(response) {
       var session = response && response.session;

--- a/js/build.js
+++ b/js/build.js
@@ -536,7 +536,13 @@ Fliplet.Widget.instance('login', function(data) {
   function handleSameTabReturn() {
     var q = readAuthReturnParams();
 
-    if (!q.token && !q.authState) return false;
+    // `error` counts as a return. A failed exchange comes back here with
+    // error+state and no credential; bailing out treated that as "not a return
+    // leg", so consumeAuthState() never ran and the URL was never cleaned. The
+    // nonce then survived in BOTH sessionStorage and the URL after being
+    // spent — and since the legacy token+user contract is still accepted, a
+    // leaked one could be replayed against a forged legacy callback.
+    if (!q.token && !q.authState && !q.error) return false;
 
     // Always consume the stored state, even on rejection — burning the
     // nonce on first arrival prevents replay if an attacker manages to
@@ -558,6 +564,18 @@ Fliplet.Widget.instance('login', function(data) {
 
     if (!expectedState || !q.state || q.state !== expectedState) {
       return reject('state nonce missing or mismatch');
+    }
+
+    // Checked after the nonce, so the nonce is consumed and the URL cleaned on
+    // this path too. No toast: the message is already rendered inline at mount
+    // (.login-error-holder), so a toast would just say the same thing twice.
+    if (q.error) {
+      // eslint-disable-next-line no-console -- security trace: failed returns need to surface for incident triage
+      console.warn('[Fliplet.Login] same-tab return carried an error:', q.error);
+      cleanAuthReturnParamsFromUrl();
+      showStart();
+
+      return true;
     }
 
     // Preferred contract: one-shot state exchange — no credentials in the URL.

--- a/js/build.js
+++ b/js/build.js
@@ -27,10 +27,16 @@ Fliplet.Widget.instance('login', function(data) {
     scheduleCheck();
   });
 
-  if (Fliplet.Navigate.query.error) {
+  // Read from location.search for the same reason handleSameTabReturn does —
+  // see readAuthReturnParams. A failed exchange returns here carrying ?error=,
+  // so this is part of the sign-in path and must not depend on which
+  // navigate.js the browser has cached.
+  var initialReturnError = readAuthReturnParams().error;
+
+  if (initialReturnError) {
     // .text(), never .html(): the error is a URL query param, so .html()
     // would be a reflected XSS sink on every app's login screen.
-    _this.$container.find('.login-error-holder').text(Fliplet.Navigate.query.error).addClass('show');
+    _this.$container.find('.login-error-holder').text(initialReturnError).addClass('show');
   }
 
   // ──────────────────────────────────────────────────────────────────────
@@ -141,6 +147,39 @@ Fliplet.Widget.instance('login', function(data) {
    * Strips the auth-return params from the URL in place so the token
    * doesn't persist in the address bar / history / bookmarks.
    */
+  // Reads the sign-in return params straight off window.location.search rather
+  // than via Fliplet.Navigate.query.
+  //
+  // Navigate.query is produced by fliplet-core's navigate.js, which until the
+  // paired API fix stripped internal params with an unanchored lookahead: it
+  // fired on the literal "&auth" inside ANY param starting with "auth", so
+  // "?state=<nonce>&authState=<uuid>" became "?state=<nonce>State=<uuid>" —
+  // authState dropped and the nonce corrupted. That asset carries a
+  // version-pinned cache-buster which does not change when the file does, so a
+  // browser holding the old copy would fail sign-in outright rather than
+  // degrading to the legacy contract.
+  //
+  // location.search is the raw browser value and no parser touches it, so
+  // reading it here makes the widget independent of which navigate.js the
+  // client happens to have cached. The API-side fix still matters for every
+  // other consumer of Navigate.query; this just removes the hard dependency
+  // from the sign-in path.
+  function readAuthReturnParams() {
+    var params = { token: null, user: null, state: null, authState: null, authHost: null, error: null };
+
+    try {
+      var qs = new URLSearchParams(window.location.search);
+
+      Object.keys(params).forEach(function(key) {
+        params[key] = qs.get(key);
+      });
+    } catch (err) {
+      console.warn('[Fliplet.Login] failed to parse return params:', err);
+    }
+
+    return params;
+  }
+
   function cleanAuthReturnParamsFromUrl() {
     if (!window.history || !window.history.replaceState) return;
 
@@ -390,74 +429,98 @@ Fliplet.Widget.instance('login', function(data) {
     }
 
     // Retarget via options.apiUrl — NOT by building an absolute options.url.
-    // Fliplet.API.request prepends the API base to *every* url, absolute ones
-    // included (core.js `options.url = apiUrl + options.url`), so an absolute
-    // URL yields https://api.fliplet.com/https://us-api.fliplet.com/... → 404.
-    // options.apiUrl replaces the base instead, which is the supported retarget
-    // (added in DEV-667). Cores predating it ignore the option and fall back to
-    // the app's own host — same-region behaviour, not a broken request.
+    // Issued as a plain XHR rather than through Fliplet.API.request, because
+    // that helper cannot express this call safely on every core version:
     //
-    // apiUrl is set unconditionally. Leaving it off does NOT fall back to the
-    // canonical API host: Fliplet.API.request's default base is
-    // Fliplet.Env.get('apiUrl'), which inside a published web app is the
-    // apps-host-proxied URL (https://apps.fliplet.com/) rather than the API
-    // host — the same distinction getApiHost() exists to paper over. Pinning it
-    // to getApiOrigin() keeps the exchange on the host that serves these routes
-    // and matches where the login URL itself was sent.
+    //  - An absolute options.url is prepended to the API base anyway
+    //    (core.js `options.url = apiUrl + options.url`, no scheme guard),
+    //    yielding https://api.fliplet.com/https://us.api.fliplet.com/… → 404.
+    //    That is the bug that got the first attempt at this feature reverted.
+    //  - The supported retarget, options.apiUrl, only landed in DEV-667
+    //    (Sep 2025). Cores predating it silently ignore it and send the
+    //    request to the app's OWN region, where a cross-region state does not
+    //    exist — so those users get a 401 and cannot sign in. Published native
+    //    bundles pin their core version, so that is not a hypothetical.
+    //
+    // Talking to the validated origin directly removes the version dependency
+    // and the double-prefix hazard together. The URL is fully controlled here:
+    // the origin has already passed safeAuthHost, and the state is encoded.
     var appOrigin = getApiOrigin();
+    var base = (safeAuthHost(authHost, appOrigin) || appOrigin).replace(/\/+$/, '');
+    var url = base + '/v1/session?state=' + encodeURIComponent(authState);
 
-    var opts = {
-      url: 'v1/session?state=' + encodeURIComponent(authState),
-      apiUrl: safeAuthHost(authHost, appOrigin) || appOrigin,
-      // The state token must be the ONLY credential this call presents.
-      //
-      // core.js fills in Fliplet.User.getAuthToken() whenever Auth-token is
-      // unset, and the API's loadUser keeps that ambient token when the state
-      // fails to resolve (expired, already consumed, Redis blip) instead of
-      // rejecting. The exchange would then return 200 with the device's
-      // PREVIOUS session and sign the user in as the wrong identity, silently
-      // — the exact opposite of what a failed exchange should do.
-      //
-      // Sending a deliberately invalid sentinel suppresses the fill-in, so an
-      // unresolvable state has nothing to fall back to and correctly 401s.
-      headers: { 'Auth-token': 'state' }
-    };
+    return new Promise(function(resolve) {
+      var xhr = new XMLHttpRequest();
 
-    return Fliplet.API.request(opts).then(function(response) {
-      var session = response && response.session;
-      var user = session && session.user;
+      function fail(reason, status) {
+        // Log the status and the host actually targeted. Without them CORS,
+        // network failure, an expired state and a wrong-region redemption all
+        // collapse into the caller's single "exchange failed" warn — and the
+        // cross-region path is the one that cannot be falsified on a local
+        // stack, so a production failure needs to be diagnosable from the log
+        // line alone.
+        console.warn('[Fliplet.Login] authState exchange failed', {
+          reason: reason,
+          status: status || 'none',
+          apiUrl: base,
+          authHostAccepted: !!safeAuthHost(authHost, appOrigin)
+        });
 
-      if (!session || !session.auth_token || !user) {
-        return null;
+        resolve(null);
       }
 
-      // Pass the user through whole rather than hand-picking fields. It is
-      // already the server's own public projection (models/session.js
-      // getPublic() omits auth_token), and it is the same object the legacy
-      // token+user contract puts in the callback URL — so every path feeds
-      // Fliplet.Hooks.run('login') an identically shaped userProfile.
-      // Reducing it here silently dropped fields for deployed web/native
-      // sign-ins only, which is exactly the kind of divergence a public hook
-      // must not have.
-      return {
-        token: session.auth_token,
-        user: user
-      };
-    }).catch(function(err) {
-      // Log the status and the host that was actually targeted. Without them
-      // CORS, network failure, an expired state and a wrong-region redemption
-      // all collapse into the caller's single "exchange failed" warn — and the
-      // cross-region path is precisely the one that cannot be falsified on a
-      // local stack, so a production failure here needs to be diagnosable from
-      // the log line alone.
-      console.warn('[Fliplet.Login] authState exchange failed', {
-        status: (err && (err.status || (err.response && err.response.status))) || 'none',
-        apiUrl: opts.apiUrl,
-        authHostAccepted: !!safeAuthHost(authHost, appOrigin),
-        message: (err && err.message) || String(err)
-      });
+      try {
+        xhr.open('GET', url, true);
+      } catch (err) {
+        return fail('open threw: ' + ((err && err.message) || err));
+      }
 
-      return null;
+      // The state token must be the ONLY credential this call presents.
+      //
+      // Without a header the API's loadUser falls back to the auth_token
+      // cookie when the state fails to resolve (expired, already consumed,
+      // Redis blip) — and on a same-origin exchange the browser sends that
+      // cookie regardless of withCredentials. The response would then be 200
+      // with the device's PREVIOUS session, signing the user in as the wrong
+      // identity. A deliberately invalid sentinel occupies req.auth_token so
+      // the cookie fallback never fires and an unresolvable state 401s.
+      xhr.setRequestHeader('Auth-token', 'state');
+      xhr.timeout = 15000;
+
+      xhr.onload = function() {
+        var session;
+
+        try {
+          session = JSON.parse(xhr.responseText).session;
+        } catch (err) {
+          return fail('response was not JSON', xhr.status);
+        }
+
+        if (xhr.status !== 200 || !session || !session.auth_token || !session.user) {
+          return fail('unexpected response shape', xhr.status);
+        }
+
+        // Pass the user through whole rather than hand-picking fields — the
+        // earlier six-field copy dropped data for deployed web/native sign-ins
+        // only. Note this is the session's user (models/session.js getPublic(),
+        // which omits auth_token); it is NOT identical to the profile the
+        // legacy token+user contract carries, which the login route enriches
+        // with host/region/organization/isFirstLogin/mustVerifyEmail and setup
+        // status. Public `login` hook consumers therefore still see a smaller
+        // object on this path — normalising the two shapes needs its own
+        // decision, since narrowing the legacy one would break consumers.
+        resolve({ token: session.auth_token, user: session.user });
+      };
+
+      xhr.onerror = function() {
+        fail('network or CORS failure', xhr.status);
+      };
+
+      xhr.ontimeout = function() {
+        fail('timed out after 15000ms');
+      };
+
+      xhr.send();
     });
   }
 
@@ -471,9 +534,9 @@ Fliplet.Widget.instance('login', function(data) {
    * normal session-restore path.
    */
   function handleSameTabReturn() {
-    var q = Fliplet.Navigate.query;
+    var q = readAuthReturnParams();
 
-    if (!q || (!q.token && !q.authState)) return false;
+    if (!q.token && !q.authState) return false;
 
     // Always consume the stored state, even on rejection — burning the
     // nonce on first arrival prevents replay if an attacker manages to

--- a/js/build.js
+++ b/js/build.js
@@ -617,8 +617,13 @@ Fliplet.Widget.instance('login', function(data) {
       var token = parsed.searchParams.get('token');
       var authState = parsed.searchParams.get('authState');
       var authHost = parsed.searchParams.get('authHost');
+      // A failed mint on the auth page returns to this same callback carrying
+      // only error+state. Without it in this guard the return is never marked
+      // handled: the IAB stays open on the callback page and the app sits
+      // behind it waiting for a result that never arrives.
+      var error = parsed.searchParams.get('error');
 
-      if (!token && !authState) return;
+      if (!token && !authState && !error) return;
 
       iabHandled = true;
 
@@ -643,6 +648,14 @@ Fliplet.Widget.instance('login', function(data) {
 
       if (!expectedState || !returnedState || returnedState !== expectedState) {
         return rejectIab('state nonce missing or mismatch');
+      }
+
+      // Checked after the nonce so a crafted ?error= link can't drive this
+      // path without a matching nonce. The server's message is logged rather
+      // than shown: it arrives via the URL, and the localised toast already
+      // says the same thing without rendering text from the query string.
+      if (error) {
+        return rejectIab('auth page reported an error: ' + error);
       }
 
       // Don't run the success path yet: on iOS a WebView navigation issued

--- a/js/build.js
+++ b/js/build.js
@@ -237,14 +237,50 @@ Fliplet.Widget.instance('login', function(data) {
       && /^token-[^@]*@fliplet\.com$/i.test(user.email);
   }
 
-  // Masks token / user / state / authState query params before logging
-  // the URL, so credentials don't surface in remote log aggregators,
-  // support-ticket screenshots, or screen recordings.
+  // Validates `authHost` before it is ever used as a request target.
+  //
+  // On the same-tab leg authHost arrives on the page query string, which the
+  // user (or anyone who can get them to open a crafted link) controls. The
+  // exchange sends the session's Authorization header to that host and feeds
+  // the response straight into handleAuthSuccess — which shape-validates the
+  // user but cannot validate its authenticity. An unvalidated host therefore
+  // buys an attacker both credential exfiltration and session fixation, so
+  // anything not provably Fliplet-owned is discarded and the caller falls
+  // back to the app's own API host (same-region behaviour).
+  //
+  // The app's own API origin is always accepted: it is the fallback target
+  // regardless, and on dev environments / local stacks it is not a
+  // fliplet.com host (e.g. https://api.fliplet.test).
+  function safeAuthHost(value) {
+    if (!value) return null;
+
+    try {
+      var u = new URL(value);
+
+      // Same origin as the app's own API host — trusted by definition.
+      if (u.origin === getApiOrigin()) return u.origin;
+
+      // Anything else must be HTTPS and Fliplet-owned. Matching on hostname
+      // (not the raw string) means "https://evil.com/?x=.fliplet.com" and
+      // "https://fliplet.com.evil.com" both fail.
+      if (u.protocol !== 'https:') return null;
+
+      return /(^|\.)fliplet\.com$/i.test(u.hostname) ? u.origin : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  // Masks token / user / state / authState / authHost query params before
+  // logging the URL, so credentials don't surface in remote log aggregators,
+  // support-ticket screenshots, or screen recordings. authHost is not itself
+  // a credential, but it is masked alongside them so a log line can't be used
+  // to confirm which region a given user's session lives in.
   function maskUrlForLogging(url) {
     try {
       var u = new URL(url);
 
-      ['token', 'user', 'state', 'authState'].forEach(function(key) {
+      ['token', 'user', 'state', 'authState', 'authHost'].forEach(function(key) {
         if (u.searchParams.has(key)) u.searchParams.set(key, '<redacted>');
       });
 
@@ -373,14 +409,21 @@ Fliplet.Widget.instance('login', function(data) {
       return Promise.resolve(null);
     }
 
-    // Absolute URL when authHost is known (Fliplet.API.request only
-    // prepends the app host to relative paths); relative otherwise.
-    var path = 'v1/session?state=' + encodeURIComponent(authState);
-    var url = authHost
-      ? String(authHost).replace(/\/+$/, '') + '/' + path
-      : path;
+    // Retarget via options.apiUrl — NOT by building an absolute options.url.
+    // Fliplet.API.request prepends the API base to *every* url, absolute ones
+    // included (core.js `options.url = apiUrl + options.url`), so an absolute
+    // URL yields https://api.fliplet.com/https://us-api.fliplet.com/... → 404.
+    // options.apiUrl replaces the base instead, which is the supported retarget
+    // (added in DEV-667). Cores predating it ignore the option and fall back to
+    // the app's own host — same-region behaviour, not a broken request.
+    var opts = { url: 'v1/session?state=' + encodeURIComponent(authState) };
+    var safeHost = safeAuthHost(authHost);
 
-    return Fliplet.API.request({ url: url }).then(function(response) {
+    if (safeHost) {
+      opts.apiUrl = safeHost;
+    }
+
+    return Fliplet.API.request(opts).then(function(response) {
       var session = response && response.session;
       var user = session && session.user;
 

--- a/js/build.js
+++ b/js/build.js
@@ -102,7 +102,11 @@ Fliplet.Widget.instance('login', function(data) {
       callback = cbBase + stateSep + 'state=' + encodeURIComponent(state) + cbFrag;
     }
 
-    var params = ['return=callback', 'callback=' + encodeURIComponent(callback)];
+    // authExchange=1 asks the auth page for the state-exchange contract:
+    // the return leg carries a one-shot authState instead of the session
+    // token + user payload, keeping credentials out of URLs (and out of
+    // host access logs, proxy logs, and browser history).
+    var params = ['return=callback', 'callback=' + encodeURIComponent(callback), 'authExchange=1'];
     var appId = Fliplet.Env.get('appId');
 
     if (appId) params.push('appId=' + encodeURIComponent(String(appId)));
@@ -123,6 +127,7 @@ Fliplet.Widget.instance('login', function(data) {
       url.searchParams.delete('token');
       url.searchParams.delete('user');
       url.searchParams.delete('state');
+      url.searchParams.delete('authState');
       url.searchParams.delete('error');
 
       return url.toString();
@@ -144,6 +149,7 @@ Fliplet.Widget.instance('login', function(data) {
       url.searchParams.delete('token');
       url.searchParams.delete('user');
       url.searchParams.delete('state');
+      url.searchParams.delete('authState');
       url.searchParams.delete('error');
       window.history.replaceState({}, document.title, url.toString());
     } catch (err) {
@@ -346,17 +352,59 @@ Fliplet.Widget.instance('login', function(data) {
   }
 
   /**
-   * Runs on widget mount. If the current URL has token + user query
-   * params, we're on the return leg of a same-tab sign-in — extract
-   * them, validate the state nonce and user shape, clean the URL, and
-   * feed the result into handleAuthSuccess. Returns true if the return
+   * Swaps a one-shot authState (minted by the auth page via
+   * POST /v1/session/authorize/state) for the signed-in session. The
+   * authenticate middleware resolves ?state= into the session's
+   * credentials server-side, so neither the session token nor the user
+   * payload ever transits a URL that reaches logs or history.
+   * @param {String} authState - One-shot AES state token from the return leg
+   * @returns {Promise<Object|null>} { token, user }, or null when the
+   *   state is invalid, expired, or the session can't be resolved
+   */
+  function exchangeAuthState(authState) {
+    if (!authState) {
+      return Promise.resolve(null);
+    }
+
+    return Fliplet.API.request({
+      url: 'v1/session?state=' + encodeURIComponent(authState)
+    }).then(function(response) {
+      var session = response && response.session;
+      var user = session && session.user;
+
+      if (!session || !session.auth_token || !user) {
+        return null;
+      }
+
+      return {
+        token: session.auth_token,
+        user: {
+          id: user.id,
+          email: user.email,
+          userRoleId: user.userRoleId,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          legacy: user.legacy
+        }
+      };
+    }).catch(function() {
+      return null;
+    });
+  }
+
+  /**
+   * Runs on widget mount. If the current URL has authState (or legacy
+   * token + user) query params, we're on the return leg of a same-tab
+   * sign-in — validate the state nonce, resolve the auth result (via the
+   * one-shot exchange, or directly on the legacy contract), clean the
+   * URL, and feed it into handleAuthSuccess. Returns true if the return
    * was handled (success OR rejection) so the caller can skip the
    * normal session-restore path.
    */
   function handleSameTabReturn() {
     var q = Fliplet.Navigate.query;
 
-    if (!q || !q.token) return false;
+    if (!q || (!q.token && !q.authState)) return false;
 
     // Always consume the stored state, even on rejection — burning the
     // nonce on first arrival prevents replay if an attacker manages to
@@ -380,6 +428,27 @@ Fliplet.Widget.instance('login', function(data) {
       return reject('state nonce missing or mismatch');
     }
 
+    // Preferred contract: one-shot state exchange — no credentials in the URL.
+    if (q.authState) {
+      var authState = q.authState;
+
+      cleanAuthReturnParamsFromUrl();
+
+      exchangeAuthState(authState).then(function(result) {
+        if (!result || !isValidUserShape(result.user)) {
+          reject('authState exchange failed or returned an invalid user');
+
+          return;
+        }
+
+        handleAuthSuccess(result);
+      });
+
+      return true;
+    }
+
+    // Legacy contract (token + user in the URL) — kept for rollout skew
+    // between the widget and the auth page.
     var user = null;
 
     try {
@@ -411,7 +480,7 @@ Fliplet.Widget.instance('login', function(data) {
     var state = generateAuthState();
     var loginUrl = buildCallbackLoginUrl(callbackBase, state);
     var iabHandled = false;
-    var pendingAuthResult = null;
+    var pendingAuth = null;
     var fallbackTimer = null;
 
     // Pre-parse the expected callback URL once for strict origin +
@@ -471,8 +540,9 @@ Fliplet.Widget.instance('login', function(data) {
       if (parsed.origin !== expectedOrigin || parsed.pathname !== expectedPathname) return;
 
       var token = parsed.searchParams.get('token');
+      var authState = parsed.searchParams.get('authState');
 
-      if (!token) return;
+      if (!token && !authState) return;
 
       iabHandled = true;
 
@@ -499,37 +569,71 @@ Fliplet.Widget.instance('login', function(data) {
         return rejectIab('state nonce missing or mismatch');
       }
 
-      var user = null;
-
-      try {
-        user = JSON.parse(parsed.searchParams.get('user') || 'null');
-      } catch (err) {
-        return rejectIab('user payload failed to parse');
-      }
-
-      if (!isValidUserShape(user)) {
-        return rejectIab('user payload failed shape validation');
-      }
-
       // Don't run the success path yet: on iOS a WebView navigation issued
       // while the IAB dismissal transition is in flight gets swallowed by
       // the native view-controller transition, so Navigate.to at the end of
-      // handleAuthSuccess would silently do nothing. Stash the result and
-      // let onExit (which Cordova fires after close() completes on both
-      // platforms) kick it off once the IAB is fully gone.
-      pendingAuthResult = { token: token, user: user };
+      // handleAuthSuccess would silently do nothing. Resolve the auth result
+      // as a promise (the exchange is an XHR from the app WebView) and let
+      // onExit — which Cordova fires after close() completes on both
+      // platforms — consume it once the IAB is fully gone.
+      if (authState) {
+        // Preferred contract: one-shot state exchange — no credentials in
+        // the sentinel URL.
+        pendingAuth = exchangeAuthState(authState).then(function(result) {
+          if (!result || !isValidUserShape(result.user)) {
+            rejectIab('authState exchange failed or returned an invalid user');
+
+            return null;
+          }
+
+          return result;
+        });
+      } else {
+        // Legacy contract (token + user in the URL) — kept for rollout skew
+        // between the widget and the auth page.
+        var user = null;
+
+        try {
+          user = JSON.parse(parsed.searchParams.get('user') || 'null');
+        } catch (err) {
+          return rejectIab('user payload failed to parse');
+        }
+
+        if (!isValidUserShape(user)) {
+          return rejectIab('user payload failed shape validation');
+        }
+
+        pendingAuth = Promise.resolve({ token: token, user: user });
+      }
 
       // Safety net if a plugin quirk drops the exit event: run the success
       // path anyway rather than stranding a completed sign-in. onExit clears
       // this timer on the normal path.
-      fallbackTimer = setTimeout(function() {
-        if (pendingAuthResult) {
-          var authResult = pendingAuthResult;
+      fallbackTimer = setTimeout(runPendingAuth, 3000);
+    }
 
-          pendingAuthResult = null;
-          handleAuthSuccess(authResult);
+    /**
+     * Consumes the pending auth result exactly once (whichever of onExit or
+     * the fallback timer gets there first) and runs the success path.
+     * @returns {Boolean} TRUE if a pending result was consumed
+     */
+    function runPendingAuth() {
+      if (!pendingAuth) {
+        return false;
+      }
+
+      var auth = pendingAuth;
+
+      pendingAuth = null;
+
+      auth.then(function(result) {
+        // A null result means the exchange already surfaced its rejection.
+        if (result) {
+          handleAuthSuccess(result);
         }
-      }, 3000);
+      });
+
+      return true;
     }
 
     function onLoadStart(event) {
@@ -560,12 +664,7 @@ Fliplet.Widget.instance('login', function(data) {
 
       // Success path: the IAB is fully dismissed now, so the navigation at
       // the end of handleAuthSuccess can't be swallowed by the transition.
-      if (pendingAuthResult) {
-        var authResult = pendingAuthResult;
-
-        pendingAuthResult = null;
-        handleAuthSuccess(authResult);
-
+      if (runPendingAuth()) {
         return;
       }
 

--- a/js/build.js
+++ b/js/build.js
@@ -240,7 +240,16 @@ Fliplet.Widget.instance('login', function(data) {
   // Validates `authHost` before it is ever used as a request target.
   // Implementation and rationale live in js/safe-auth-host.js, which is loaded
   // ahead of this file by widget.json so it can also be unit tested in Node.
-  var safeAuthHost = window.FlipletLoginAuthHost.safeAuthHost;
+  //
+  // Resolved defensively: if the asset doesn't land, dereferencing it directly
+  // would throw at widget init and take the whole login screen down. Falling
+  // back to "reject everything" degrades to same-region sign-in, which is what
+  // an unvalidatable authHost should do anyway.
+  var safeAuthHost = (window.FlipletLoginAuthHost || {}).safeAuthHost || function() {
+    console.warn('[Fliplet.Login] safe-auth-host asset missing; authHost will be ignored');
+
+    return null;
+  };
 
   // Masks token / user / state / authState / authHost query params before
   // logging the URL, so credentials don't surface in remote log aggregators,
@@ -434,7 +443,20 @@ Fliplet.Widget.instance('login', function(data) {
         token: session.auth_token,
         user: user
       };
-    }).catch(function() {
+    }).catch(function(err) {
+      // Log the status and the host that was actually targeted. Without them
+      // CORS, network failure, an expired state and a wrong-region redemption
+      // all collapse into the caller's single "exchange failed" warn — and the
+      // cross-region path is precisely the one that cannot be falsified on a
+      // local stack, so a production failure here needs to be diagnosable from
+      // the log line alone.
+      console.warn('[Fliplet.Login] authState exchange failed', {
+        status: (err && (err.status || (err.response && err.response.status))) || 'none',
+        apiUrl: opts.apiUrl,
+        authHostAccepted: !!safeAuthHost(authHost, appOrigin),
+        message: (err && err.message) || String(err)
+      });
+
       return null;
     });
   }
@@ -685,6 +707,14 @@ Fliplet.Widget.instance('login', function(data) {
         if (result) {
           handleAuthSuccess(result);
         }
+      }).catch(function(err) {
+        // Same hazard the same-tab path guards against: a throw inside
+        // handleAuthSuccess would otherwise be an unhandled rejection with no
+        // toast and no showStart(), leaving the loader up indefinitely.
+        console.warn('[Fliplet.Login] native auth completion threw:', err);
+        Fliplet.UI.Toast.error(T('widgets.login.fliplet.errors.unableLogin'));
+        hideLoadingState();
+        showStart();
       });
 
       return true;

--- a/js/build.js
+++ b/js/build.js
@@ -256,16 +256,38 @@ Fliplet.Widget.instance('login', function(data) {
 
     try {
       var u = new URL(value);
+      var appOrigin = getApiOrigin();
+      var app = new URL(appOrigin);
 
       // Same origin as the app's own API host — trusted by definition.
-      if (u.origin === getApiOrigin()) return u.origin;
+      if (u.origin === appOrigin) return u.origin;
 
-      // Anything else must be HTTPS and Fliplet-owned. Matching on hostname
-      // (not the raw string) means "https://evil.com/?x=.fliplet.com" and
-      // "https://fliplet.com.evil.com" both fail.
-      if (u.protocol !== 'https:') return null;
+      // Production regional hosts (us-api.fliplet.com, ca-api.fliplet.com…).
+      // Matching on the parsed hostname (not the raw string) means
+      // "https://evil.com/?x=.fliplet.com" and "https://fliplet.com.evil.com"
+      // both fail.
+      if (u.protocol === 'https:' && /(^|\.)fliplet\.com$/i.test(u.hostname)) {
+        return u.origin;
+      }
 
-      return /(^|\.)fliplet\.com$/i.test(u.hostname) ? u.origin : null;
+      // Regional siblings of the app's own API host, for dev environments and
+      // local stacks whose regions are NOT fliplet.com hosts — e.g.
+      // us.api.fliplet.test alongside api.fliplet.test. Without this the US
+      // host is rejected off-production and the exchange silently falls back
+      // to the app's own (wrong-region) host, which masks cross-region bugs
+      // in exactly the environments used to test for them.
+      //
+      // The permitted suffix is derived from the app's OWN api host and
+      // requires a full label boundary, so a crafted authHost cannot widen it,
+      // and it never falls back to a registrable-domain guess (which would
+      // wrongly allow any *.co.uk for a custom domain on a public suffix).
+      if (u.protocol === app.protocol
+        && u.hostname.length > app.hostname.length
+        && u.hostname.slice(-(app.hostname.length + 1)) === '.' + app.hostname) {
+        return u.origin;
+      }
+
+      return null;
     } catch (err) {
       return null;
     }

--- a/js/build.js
+++ b/js/build.js
@@ -238,60 +238,9 @@ Fliplet.Widget.instance('login', function(data) {
   }
 
   // Validates `authHost` before it is ever used as a request target.
-  //
-  // On the same-tab leg authHost arrives on the page query string, which the
-  // user (or anyone who can get them to open a crafted link) controls. The
-  // exchange sends the session's Authorization header to that host and feeds
-  // the response straight into handleAuthSuccess — which shape-validates the
-  // user but cannot validate its authenticity. An unvalidated host therefore
-  // buys an attacker both credential exfiltration and session fixation, so
-  // anything not provably Fliplet-owned is discarded and the caller falls
-  // back to the app's own API host (same-region behaviour).
-  //
-  // The app's own API origin is always accepted: it is the fallback target
-  // regardless, and on dev environments / local stacks it is not a
-  // fliplet.com host (e.g. https://api.fliplet.test).
-  function safeAuthHost(value) {
-    if (!value) return null;
-
-    try {
-      var u = new URL(value);
-      var appOrigin = getApiOrigin();
-      var app = new URL(appOrigin);
-
-      // Same origin as the app's own API host — trusted by definition.
-      if (u.origin === appOrigin) return u.origin;
-
-      // Production regional hosts (us-api.fliplet.com, ca-api.fliplet.com…).
-      // Matching on the parsed hostname (not the raw string) means
-      // "https://evil.com/?x=.fliplet.com" and "https://fliplet.com.evil.com"
-      // both fail.
-      if (u.protocol === 'https:' && /(^|\.)fliplet\.com$/i.test(u.hostname)) {
-        return u.origin;
-      }
-
-      // Regional siblings of the app's own API host, for dev environments and
-      // local stacks whose regions are NOT fliplet.com hosts — e.g.
-      // us.api.fliplet.test alongside api.fliplet.test. Without this the US
-      // host is rejected off-production and the exchange silently falls back
-      // to the app's own (wrong-region) host, which masks cross-region bugs
-      // in exactly the environments used to test for them.
-      //
-      // The permitted suffix is derived from the app's OWN api host and
-      // requires a full label boundary, so a crafted authHost cannot widen it,
-      // and it never falls back to a registrable-domain guess (which would
-      // wrongly allow any *.co.uk for a custom domain on a public suffix).
-      if (u.protocol === app.protocol
-        && u.hostname.length > app.hostname.length
-        && u.hostname.slice(-(app.hostname.length + 1)) === '.' + app.hostname) {
-        return u.origin;
-      }
-
-      return null;
-    } catch (err) {
-      return null;
-    }
-  }
+  // Implementation and rationale live in js/safe-auth-host.js, which is loaded
+  // ahead of this file by widget.json so it can also be unit tested in Node.
+  var safeAuthHost = window.FlipletLoginAuthHost.safeAuthHost;
 
   // Masks token / user / state / authState / authHost query params before
   // logging the URL, so credentials don't surface in remote log aggregators,
@@ -446,9 +395,23 @@ Fliplet.Widget.instance('login', function(data) {
     // host — the same distinction getApiHost() exists to paper over. Pinning it
     // to getApiOrigin() keeps the exchange on the host that serves these routes
     // and matches where the login URL itself was sent.
+    var appOrigin = getApiOrigin();
+
     var opts = {
       url: 'v1/session?state=' + encodeURIComponent(authState),
-      apiUrl: safeAuthHost(authHost) || getApiOrigin()
+      apiUrl: safeAuthHost(authHost, appOrigin) || appOrigin,
+      // The state token must be the ONLY credential this call presents.
+      //
+      // core.js fills in Fliplet.User.getAuthToken() whenever Auth-token is
+      // unset, and the API's loadUser keeps that ambient token when the state
+      // fails to resolve (expired, already consumed, Redis blip) instead of
+      // rejecting. The exchange would then return 200 with the device's
+      // PREVIOUS session and sign the user in as the wrong identity, silently
+      // — the exact opposite of what a failed exchange should do.
+      //
+      // Sending a deliberately invalid sentinel suppresses the fill-in, so an
+      // unresolvable state has nothing to fall back to and correctly 401s.
+      headers: { 'Auth-token': 'state' }
     };
 
     return Fliplet.API.request(opts).then(function(response) {
@@ -459,16 +422,17 @@ Fliplet.Widget.instance('login', function(data) {
         return null;
       }
 
+      // Pass the user through whole rather than hand-picking fields. It is
+      // already the server's own public projection (models/session.js
+      // getPublic() omits auth_token), and it is the same object the legacy
+      // token+user contract puts in the callback URL — so every path feeds
+      // Fliplet.Hooks.run('login') an identically shaped userProfile.
+      // Reducing it here silently dropped fields for deployed web/native
+      // sign-ins only, which is exactly the kind of divergence a public hook
+      // must not have.
       return {
         token: session.auth_token,
-        user: {
-          id: user.id,
-          email: user.email,
-          userRoleId: user.userRoleId,
-          firstName: user.firstName,
-          lastName: user.lastName,
-          legacy: user.legacy
-        }
+        user: user
       };
     }).catch(function() {
       return null;
@@ -526,6 +490,11 @@ Fliplet.Widget.instance('login', function(data) {
         }
 
         handleAuthSuccess(result);
+      }).catch(function() {
+        // exchangeAuthState swallows its own request failure, so reaching here
+        // means handleAuthSuccess threw. Without this the rejection is
+        // unhandled: no toast, no showStart(), loader up indefinitely.
+        reject('exchange threw');
       });
 
       return true;

--- a/js/build.js
+++ b/js/build.js
@@ -34,9 +34,17 @@ Fliplet.Widget.instance('login', function(data) {
   var initialReturnError = readAuthReturnParams().error;
 
   if (initialReturnError) {
-    // .text(), never .html(): the error is a URL query param, so .html()
-    // would be a reflected XSS sink on every app's login screen.
-    _this.$container.find('.login-error-holder').text(initialReturnError).addClass('show');
+    // Show the localised string, NOT the server's — this runs at mount, before
+    // any nonce has been validated, and ?error= is reachable by anyone who can
+    // get the user to open a link. .text() means this was never an XSS sink,
+    // but rendering an attacker-chosen string into the app's own login error
+    // area is still a social-engineering primitive ("Your account is locked,
+    // call 0800-…"). handleSameTabReturn upgrades this to the real message
+    // once the nonce matches; the raw value is logged either way for triage.
+    // The IAB leg already takes this position — the two are now symmetric.
+    // eslint-disable-next-line no-console -- security trace: unauthenticated error params need to surface for incident triage
+    console.warn('[Fliplet.Login] return carried an error param:', initialReturnError);
+    showLoginError(genericLoginError());
   }
 
   // ──────────────────────────────────────────────────────────────────────
@@ -53,6 +61,28 @@ Fliplet.Widget.instance('login', function(data) {
 
       scheduleCheck();
     }, 500);
+  }
+
+  // .text(), never .html(): these strings can originate from a URL query
+  // param, so .html() would be a reflected XSS sink on every app's login
+  // screen.
+  function showLoginError(message) {
+    _this.$container.find('.login-error-holder').text(message).addClass('show');
+  }
+
+  // T is a runtime global rather than a module import, and this can be called
+  // at mount before the translation layer is guaranteed ready — fall back to
+  // the literal rather than throwing on the sign-in path.
+  function genericLoginError() {
+    if (typeof T === 'function') {
+      try {
+        return T('widgets.login.fliplet.errors.unableLogin');
+      } catch (err) {
+        // fall through
+      }
+    }
+
+    return 'Sign-in could not be completed. Please try again.';
   }
 
   function showStart() {
@@ -579,6 +609,9 @@ Fliplet.Widget.instance('login', function(data) {
     if (q.error) {
       // eslint-disable-next-line no-console -- security trace: failed returns need to surface for incident triage
       console.warn('[Fliplet.Login] same-tab return carried an error:', q.error);
+      // The nonce matched, so this really is our own auth page's message and
+      // can replace the generic one rendered at mount.
+      showLoginError(q.error);
       cleanAuthReturnParamsFromUrl();
       showStart();
 

--- a/js/build.js
+++ b/js/build.js
@@ -128,6 +128,7 @@ Fliplet.Widget.instance('login', function(data) {
       url.searchParams.delete('user');
       url.searchParams.delete('state');
       url.searchParams.delete('authState');
+      url.searchParams.delete('authHost');
       url.searchParams.delete('error');
 
       return url.toString();
@@ -150,6 +151,7 @@ Fliplet.Widget.instance('login', function(data) {
       url.searchParams.delete('user');
       url.searchParams.delete('state');
       url.searchParams.delete('authState');
+      url.searchParams.delete('authHost');
       url.searchParams.delete('error');
       window.history.replaceState({}, document.title, url.toString());
     } catch (err) {
@@ -235,14 +237,14 @@ Fliplet.Widget.instance('login', function(data) {
       && /^token-[^@]*@fliplet\.com$/i.test(user.email);
   }
 
-  // Masks token / user / state query params before logging the URL,
-  // so the token doesn't surface in remote log aggregators, support-
-  // ticket screenshots, or screen recordings.
+  // Masks token / user / state / authState query params before logging
+  // the URL, so credentials don't surface in remote log aggregators,
+  // support-ticket screenshots, or screen recordings.
   function maskUrlForLogging(url) {
     try {
       var u = new URL(url);
 
-      ['token', 'user', 'state'].forEach(function(key) {
+      ['token', 'user', 'state', 'authState'].forEach(function(key) {
         if (u.searchParams.has(key)) u.searchParams.set(key, '<redacted>');
       });
 
@@ -357,18 +359,28 @@ Fliplet.Widget.instance('login', function(data) {
    * authenticate middleware resolves ?state= into the session's
    * credentials server-side, so neither the session token nor the user
    * payload ever transits a URL that reaches logs or history.
-   * @param {String} authState - One-shot AES state token from the return leg
+   * @param {String} authState - One-shot state token from the return leg
+   * @param {String} [authHost] - Host that minted the token. The token is
+   *   single-use Redis and region-local, so it must be redeemed on its
+   *   issuing host — which for a cross-region user differs from this app's
+   *   API host. Absent only on rollout skew (old API); falls back to the
+   *   app's own API host, i.e. the pre-existing same-region behaviour.
    * @returns {Promise<Object|null>} { token, user }, or null when the
    *   state is invalid, expired, or the session can't be resolved
    */
-  function exchangeAuthState(authState) {
+  function exchangeAuthState(authState, authHost) {
     if (!authState) {
       return Promise.resolve(null);
     }
 
-    return Fliplet.API.request({
-      url: 'v1/session?state=' + encodeURIComponent(authState)
-    }).then(function(response) {
+    // Absolute URL when authHost is known (Fliplet.API.request only
+    // prepends the app host to relative paths); relative otherwise.
+    var path = 'v1/session?state=' + encodeURIComponent(authState);
+    var url = authHost
+      ? String(authHost).replace(/\/+$/, '') + '/' + path
+      : path;
+
+    return Fliplet.API.request({ url: url }).then(function(response) {
       var session = response && response.session;
       var user = session && session.user;
 
@@ -431,10 +443,11 @@ Fliplet.Widget.instance('login', function(data) {
     // Preferred contract: one-shot state exchange — no credentials in the URL.
     if (q.authState) {
       var authState = q.authState;
+      var authHost = q.authHost;
 
       cleanAuthReturnParamsFromUrl();
 
-      exchangeAuthState(authState).then(function(result) {
+      exchangeAuthState(authState, authHost).then(function(result) {
         if (!result || !isValidUserShape(result.user)) {
           reject('authState exchange failed or returned an invalid user');
 
@@ -541,6 +554,7 @@ Fliplet.Widget.instance('login', function(data) {
 
       var token = parsed.searchParams.get('token');
       var authState = parsed.searchParams.get('authState');
+      var authHost = parsed.searchParams.get('authHost');
 
       if (!token && !authState) return;
 
@@ -579,7 +593,7 @@ Fliplet.Widget.instance('login', function(data) {
       if (authState) {
         // Preferred contract: one-shot state exchange — no credentials in
         // the sentinel URL.
-        pendingAuth = exchangeAuthState(authState).then(function(result) {
+        pendingAuth = exchangeAuthState(authState, authHost).then(function(result) {
           if (!result || !isValidUserShape(result.user)) {
             rejectIab('authState exchange failed or returned an invalid user');
 

--- a/js/safe-auth-host.js
+++ b/js/safe-auth-host.js
@@ -1,0 +1,91 @@
+/**
+ * Validation for the `authHost` parameter used by the one-shot authState
+ * exchange (DEV-1633).
+ *
+ * Lives in its own file, and takes the app's API origin as an argument rather
+ * than reading it from the widget scope, so it is a pure function that can be
+ * exercised directly by test/safe-auth-host.test.js. js/build.js cannot be
+ * loaded outside a browser (it calls Fliplet.Widget.instance at module scope),
+ * and this is the one piece of that file that most needs committed coverage:
+ * a missing allowlist here was one of the two blocking findings that caused
+ * the original DEV-1572 revert.
+ */
+(function(root, factory) {
+  var api = factory();
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    root.FlipletLoginAuthHost = api;
+  }
+}(typeof self !== 'undefined' ? self : this, function() {
+  /**
+   * Validates `authHost` before it is ever used as a request target.
+   *
+   * On the same-tab leg authHost arrives on the page query string, which the
+   * user (or anyone who can get them to open a crafted link) controls. The
+   * exchange sends the session's Authorization header to that host and feeds
+   * the response straight into handleAuthSuccess — which shape-validates the
+   * user but cannot validate its authenticity. An unvalidated host therefore
+   * buys an attacker both credential exfiltration and session fixation, so
+   * anything not provably Fliplet-owned is discarded and the caller falls
+   * back to the app's own API host (same-region behaviour).
+   *
+   * @param {String} value - untrusted authHost from the query string
+   * @param {String} appOrigin - the app's own API origin (trusted)
+   * @returns {String|null} the accepted origin, or null to fall back
+   */
+  function safeAuthHost(value, appOrigin) {
+    if (!value || !appOrigin) return null;
+
+    try {
+      var u = new URL(value);
+      var app = new URL(appOrigin);
+
+      // The app's own API origin is always accepted: it is the fallback target
+      // regardless, and on dev environments / local stacks it is not a
+      // fliplet.com host (e.g. https://api.fliplet.test).
+      if (u.origin === app.origin) return u.origin;
+
+      // Production and staging regional API hosts. The legitimate target set
+      // is small and known — api.fliplet.com plus one label per region
+      // (us.api, ca.api, staging.api, staging-us.api…) — so this matches those
+      // rather than all of *.fliplet.com, which would also cover
+      // apps.fliplet.com and the 13 *.studio-apps.fliplet.com origins. This
+      // call carries the Authorization header and feeds handleAuthSuccess, so
+      // the narrower set is worth the specificity. New regions are covered
+      // automatically.
+      //
+      // Matching on the parsed hostname (not the raw string) means
+      // "https://evil.com/?x=.fliplet.com" and "https://fliplet.com.evil.com"
+      // both fail. The optional label must end in a dot, so "xapi.fliplet.com"
+      // fails too.
+      if (u.protocol === 'https:' && /^([a-z0-9-]+\.)?api\.fliplet\.com$/i.test(u.hostname)) {
+        return u.origin;
+      }
+
+      // Regional siblings of the app's own API host, for dev environments and
+      // local stacks whose regions are NOT fliplet.com hosts — e.g.
+      // us.api.fliplet.test alongside api.fliplet.test. Without this the US
+      // host is rejected off-production and the exchange silently falls back
+      // to the app's own (wrong-region) host, which masks cross-region bugs in
+      // exactly the environments used to test for them.
+      //
+      // The permitted suffix is derived from the app's OWN api host and
+      // requires a full label boundary, so a crafted authHost cannot widen it,
+      // and it never falls back to a registrable-domain guess (which would
+      // wrongly allow any *.co.uk for a custom domain on a public suffix).
+      if (u.protocol === app.protocol
+        && u.hostname.length > app.hostname.length
+        && u.hostname.slice(-(app.hostname.length + 1)) === '.' + app.hostname) {
+        return u.origin;
+      }
+
+      return null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  return { safeAuthHost: safeAuthHost };
+}));

--- a/js/safe-auth-host.js
+++ b/js/safe-auth-host.js
@@ -47,6 +47,12 @@
       // fliplet.com host (e.g. https://api.fliplet.test).
       if (u.origin === app.origin) return u.origin;
 
+      // Every rule below matches on u.hostname, which carries no port, while
+      // the function returns u.origin, which does. Without this an attacker
+      // who satisfies a hostname rule can still redirect the redemption to an
+      // arbitrary port on that host (https://api.fliplet.com:31337).
+      if (u.port !== '' && u.port !== app.port) return null;
+
       // Production and staging regional API hosts. The legitimate target set
       // is small and known — api.fliplet.com plus one label per region
       // (us.api, ca.api, staging.api, staging-us.api…) — so this matches those
@@ -60,7 +66,13 @@
       // "https://evil.com/?x=.fliplet.com" and "https://fliplet.com.evil.com"
       // both fail. The optional label must end in a dot, so "xapi.fliplet.com"
       // fails too.
-      if (u.protocol === 'https:' && /^([a-z0-9-]+\.)?api\.fliplet\.com$/i.test(u.hostname)) {
+      // The cdn[.-] exclusion is load-bearing, not defensive padding. The CDN
+      // origins in config/production.json are cdn.api.fliplet.com and
+      // cdn-staging.api.fliplet.com — a single label under api.fliplet.com,
+      // structurally identical to a region. Without the lookahead they satisfy
+      // this rule and receive the Authorization header. Their regional
+      // siblings (us.cdn / ca.cdn) carry two labels and are already excluded.
+      if (u.protocol === 'https:' && /^(?!cdn[.-])([a-z0-9-]+\.)?api\.fliplet\.com$/i.test(u.hostname)) {
         return u.origin;
       }
 
@@ -71,11 +83,21 @@
       // to the app's own (wrong-region) host, which masks cross-region bugs in
       // exactly the environments used to test for them.
       //
-      // The permitted suffix is derived from the app's OWN api host and
-      // requires a full label boundary, so a crafted authHost cannot widen it,
-      // and it never falls back to a registrable-domain guess (which would
-      // wrongly allow any *.co.uk for a custom domain on a public suffix).
+      // Deliberately scoped OFF production. On fliplet.com the rule above is
+      // the whole allowlist, and this one would undo its narrowness: the real
+      // CDN origins in config/production.json (cdn.api.fliplet.com,
+      // us.cdn.api.fliplet.com, ca.cdn.api.fliplet.com) are all subdomains of
+      // api.fliplet.com, so a bare suffix check hands them the Authorization
+      // header — the exact shape the rule above exists to prevent.
+      //
+      // Exactly ONE label, so it cannot walk down an arbitrary depth of
+      // subdomains, and the suffix is derived from the app's own host, so a
+      // crafted authHost cannot widen it. It never falls back to a
+      // registrable-domain guess (which would wrongly allow any *.co.uk for a
+      // custom domain on a public suffix).
       if (u.protocol === app.protocol
+        && !/(^|\.)fliplet\.com$/i.test(app.hostname)
+        && /^[a-z0-9-]+$/i.test(u.hostname.slice(0, Math.max(0, u.hostname.length - app.hostname.length - 1)))
         && u.hostname.length > app.hostname.length
         && u.hostname.slice(-(app.hostname.length + 1)) === '.' + app.hostname) {
         return u.origin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "node --test test/"
+    "test": "node --test"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test test/"
+  },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "eslint": "^8.2.0",

--- a/test/safe-auth-host.test.js
+++ b/test/safe-auth-host.test.js
@@ -108,15 +108,17 @@ test('accepts regional siblings of a non-fliplet.com app host', () => {
   );
 });
 
-test('sibling rule never applies on production, so CDN origins stay out', () => {
-  // cdn.api.fliplet.com / us.cdn.api.fliplet.com / ca.cdn.api.fliplet.com are
-  // the real CDN hosts in config/production.json and are genuine subdomains of
-  // api.fliplet.com. A bare suffix check would hand them the Authorization
-  // header, undoing the narrowness of the regional-host rule above.
-  // Every api.fliplet.com host that appears in config/*.json, split by whether
-  // it is a redemption target. cdn.api.fliplet.com is a SINGLE label under
-  // api.fliplet.com — structurally identical to a region — so it passes the
-  // regional-host rule unless explicitly excluded.
+// Named for what it actually guards. Two independent rules are involved: the
+// CDN exclusion lives on the production regional rule (cdn is a single label,
+// so the sibling rule never even sees it), while the depth limit comes from
+// the sibling rule being disabled on fliplet.com. Either one alone leaves a
+// hole, so both are asserted together.
+test('production allowlist excludes CDN origins and arbitrary subdomain depth', () => {
+  // The CDN hosts in config/production.json are genuine subdomains of
+  // api.fliplet.com, and cdn.api.fliplet.com is a SINGLE label under it —
+  // structurally identical to a region — so it passes the regional-host rule
+  // unless explicitly excluded. A bare suffix check would hand all of them the
+  // Authorization header, undoing the narrowness of that rule.
   const cdnHosts = [
     'https://cdn.api.fliplet.com',
     'https://cdn-staging.api.fliplet.com',
@@ -130,12 +132,16 @@ test('sibling rule never applies on production, so CDN origins stay out', () => 
     assert.strictEqual(safeAuthHost(host, 'https://us.api.fliplet.com'), null, host);
   }
 
-  for (const host of ['https://anything.api.fliplet.com', 'https://a.b.c.api.fliplet.com']) {
-    // Arbitrary single labels are still accepted by the regional rule by
-    // design (new regions must work without a code change); arbitrary DEPTH
-    // is not.
-    assert.strictEqual(safeAuthHost('https://a.b.c.api.fliplet.com', PROD), null, host);
-  }
+  // Depth is what the exclusion is about, NOT label content. An arbitrary
+  // single label is accepted by design so a new region works without a code
+  // change — asserted explicitly here so nobody "tightens" it by mistake.
+  // These two are deliberately separate assertions rather than a loop: they
+  // have opposite expected values.
+  assert.strictEqual(
+    safeAuthHost('https://anything.api.fliplet.com', PROD),
+    'https://anything.api.fliplet.com'
+  );
+  assert.strictEqual(safeAuthHost('https://a.b.c.api.fliplet.com', PROD), null);
 
   // The real API hosts must all survive the exclusion.
   for (const host of ['https://staging.api.fliplet.com', 'https://staging-us.api.fliplet.com', 'https://development.api.fliplet.com']) {

--- a/test/safe-auth-host.test.js
+++ b/test/safe-auth-host.test.js
@@ -1,0 +1,154 @@
+/**
+ * Coverage for safeAuthHost (DEV-1633).
+ *
+ * A missing authHost allowlist was one of the two blocking findings that
+ * caused the original DEV-1572 revert, so the hostile inputs it has to reject
+ * belong in the repo rather than in a throwaway harness.
+ *
+ * Run with: npm test   (node --test, no dependencies)
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { safeAuthHost } = require('../js/safe-auth-host');
+
+const PROD = 'https://api.fliplet.com';
+const LOCAL = 'https://api.fliplet.test';
+
+test('accepts the app\'s own API origin', () => {
+  assert.strictEqual(safeAuthHost(PROD, PROD), PROD);
+  assert.strictEqual(safeAuthHost(LOCAL, LOCAL), LOCAL);
+  // Trailing slash: the parsed origin is returned, not the raw input.
+  assert.strictEqual(safeAuthHost(PROD + '/', PROD), PROD);
+});
+
+test('accepts every production and staging regional API host', () => {
+  const hosts = [
+    'https://api.fliplet.com',
+    'https://us.api.fliplet.com',
+    'https://ca.api.fliplet.com',
+    'https://staging.api.fliplet.com',
+    'https://staging-us.api.fliplet.com'
+  ];
+
+  for (const host of hosts) {
+    assert.strictEqual(safeAuthHost(host, PROD), host, host);
+  }
+});
+
+test('accepts a future region without a code change', () => {
+  assert.strictEqual(
+    safeAuthHost('https://au.api.fliplet.com', PROD),
+    'https://au.api.fliplet.com'
+  );
+});
+
+test('rejects non-API fliplet.com hosts', () => {
+  // These would all have passed a bare /(^|\.)fliplet\.com$/ test.
+  const hosts = [
+    'https://fliplet.com',
+    'https://apps.fliplet.com',
+    'https://us-apps.fliplet.com',
+    'https://analytics.studio-apps.fliplet.com',
+    'https://domains.studio-apps.fliplet.com',
+    'https://xapi.fliplet.com'
+  ];
+
+  for (const host of hosts) {
+    assert.strictEqual(safeAuthHost(host, PROD), null, host);
+  }
+});
+
+test('rejects suffix and query-string spoofs', () => {
+  const hosts = [
+    'https://fliplet.com.evil.com',
+    'https://api.fliplet.com.evil.com',
+    'https://evil.com/?x=.fliplet.com',
+    'https://evil.com/#api.fliplet.com',
+    'https://evil.com/api.fliplet.com',
+    'https://notfliplet.com',
+    'https://api.fliplet.com.co',
+    'https://user:pass@evil.com/'
+  ];
+
+  for (const host of hosts) {
+    assert.strictEqual(safeAuthHost(host, PROD), null, host);
+  }
+});
+
+test('rejects credential-bearing userinfo pointing at a valid host', () => {
+  // The origin here is evil.com, not api.fliplet.com.
+  assert.strictEqual(safeAuthHost('https://api.fliplet.com@evil.com/', PROD), null);
+});
+
+test('rejects non-https schemes in production', () => {
+  const hosts = [
+    'http://api.fliplet.com',
+    'ftp://api.fliplet.com',
+    'javascript:alert(1)//api.fliplet.com',
+    'data:text/html,<script>1</script>'
+  ];
+
+  for (const host of hosts) {
+    assert.strictEqual(safeAuthHost(host, PROD), null, host);
+  }
+});
+
+test('accepts regional siblings of a non-fliplet.com app host', () => {
+  // Dev environments and local stacks: us.api.fliplet.test alongside
+  // api.fliplet.test. Rejecting these is what silently masked cross-region
+  // bugs in the environments used to test for them.
+  assert.strictEqual(
+    safeAuthHost('https://us.api.fliplet.test', LOCAL),
+    'https://us.api.fliplet.test'
+  );
+  assert.strictEqual(
+    safeAuthHost('https://ca.api.fliplet.test', LOCAL),
+    'https://ca.api.fliplet.test'
+  );
+});
+
+test('sibling rule requires a full label boundary', () => {
+  // "evilapi.fliplet.test" ends with "api.fliplet.test" as a raw substring but
+  // is not a subdomain of it.
+  assert.strictEqual(safeAuthHost('https://evilapi.fliplet.test', LOCAL), null);
+  assert.strictEqual(safeAuthHost('https://xapi.fliplet.test', LOCAL), null);
+});
+
+test('sibling rule does not widen to the parent domain', () => {
+  // A shorter or equal-length hostname must not pass the suffix check.
+  assert.strictEqual(safeAuthHost('https://fliplet.test', LOCAL), null);
+  assert.strictEqual(safeAuthHost('https://test', LOCAL), null);
+});
+
+test('sibling rule does not cross protocols', () => {
+  assert.strictEqual(safeAuthHost('http://us.api.fliplet.test', LOCAL), null);
+});
+
+test('does not reduce to a registrable domain on a public suffix', () => {
+  // An app on api.acme.co.uk must not end up trusting anything under co.uk.
+  const appOrigin = 'https://api.acme.co.uk';
+
+  assert.strictEqual(safeAuthHost('https://evil.co.uk', appOrigin), null);
+  assert.strictEqual(safeAuthHost('https://acme.co.uk', appOrigin), null);
+  // A genuine subdomain of the app's own host is still fine.
+  assert.strictEqual(
+    safeAuthHost('https://us.api.acme.co.uk', appOrigin),
+    'https://us.api.acme.co.uk'
+  );
+});
+
+test('rejects empty, malformed and non-string input', () => {
+  const inputs = ['', null, undefined, 'not a url', '//api.fliplet.com', '/v1/session', {}, 42];
+
+  for (const input of inputs) {
+    assert.strictEqual(safeAuthHost(input, PROD), null, String(input));
+  }
+});
+
+test('rejects everything when the app origin is missing', () => {
+  // Without a trusted reference there is nothing to validate against, so the
+  // caller must fall back rather than trust the query string.
+  assert.strictEqual(safeAuthHost(PROD, ''), null);
+  assert.strictEqual(safeAuthHost(PROD, undefined), null);
+});

--- a/test/safe-auth-host.test.js
+++ b/test/safe-auth-host.test.js
@@ -108,6 +108,69 @@ test('accepts regional siblings of a non-fliplet.com app host', () => {
   );
 });
 
+test('sibling rule never applies on production, so CDN origins stay out', () => {
+  // cdn.api.fliplet.com / us.cdn.api.fliplet.com / ca.cdn.api.fliplet.com are
+  // the real CDN hosts in config/production.json and are genuine subdomains of
+  // api.fliplet.com. A bare suffix check would hand them the Authorization
+  // header, undoing the narrowness of the regional-host rule above.
+  // Every api.fliplet.com host that appears in config/*.json, split by whether
+  // it is a redemption target. cdn.api.fliplet.com is a SINGLE label under
+  // api.fliplet.com — structurally identical to a region — so it passes the
+  // regional-host rule unless explicitly excluded.
+  const cdnHosts = [
+    'https://cdn.api.fliplet.com',
+    'https://cdn-staging.api.fliplet.com',
+    'https://us.cdn.api.fliplet.com',
+    'https://ca.cdn.api.fliplet.com'
+  ];
+
+  for (const host of cdnHosts) {
+    assert.strictEqual(safeAuthHost(host, PROD), null, host);
+    // Also when the app is itself on a regional host.
+    assert.strictEqual(safeAuthHost(host, 'https://us.api.fliplet.com'), null, host);
+  }
+
+  for (const host of ['https://anything.api.fliplet.com', 'https://a.b.c.api.fliplet.com']) {
+    // Arbitrary single labels are still accepted by the regional rule by
+    // design (new regions must work without a code change); arbitrary DEPTH
+    // is not.
+    assert.strictEqual(safeAuthHost('https://a.b.c.api.fliplet.com', PROD), null, host);
+  }
+
+  // The real API hosts must all survive the exclusion.
+  for (const host of ['https://staging.api.fliplet.com', 'https://staging-us.api.fliplet.com', 'https://development.api.fliplet.com']) {
+    assert.strictEqual(safeAuthHost(host, PROD), host, host);
+  }
+});
+
+test('sibling rule permits exactly one label off production', () => {
+  assert.strictEqual(
+    safeAuthHost('https://us.api.fliplet.test', LOCAL),
+    'https://us.api.fliplet.test'
+  );
+  // Deeper nesting must not walk down arbitrary subdomains.
+  assert.strictEqual(safeAuthHost('https://a.b.api.fliplet.test', LOCAL), null);
+  assert.strictEqual(safeAuthHost('https://cdn.us.api.fliplet.test', LOCAL), null);
+});
+
+test('rejects a non-matching port on every branch', () => {
+  // The rules match on hostname (port-free) but the function returns origin
+  // (port-bearing), so the port needs its own check.
+  assert.strictEqual(safeAuthHost('https://api.fliplet.com:31337', PROD), null);
+  assert.strictEqual(safeAuthHost('https://us.api.fliplet.com:8443', PROD), null);
+  assert.strictEqual(safeAuthHost('https://us.api.fliplet.test:9443', LOCAL), null);
+  // An explicit default port is normalised away by URL, so it still matches.
+  assert.strictEqual(safeAuthHost('https://us.api.fliplet.com:443', PROD), 'https://us.api.fliplet.com');
+});
+
+test('rejects trailing-dot FQDNs', () => {
+  // Resolves to the same host but is a distinct origin; easy to loosen by
+  // accident in a refactor.
+  assert.strictEqual(safeAuthHost('https://us.api.fliplet.com.', PROD), null);
+  assert.strictEqual(safeAuthHost('https://api.fliplet.com.', PROD), null);
+  assert.strictEqual(safeAuthHost('https://us.api.fliplet.test.', LOCAL), null);
+});
+
 test('sibling rule requires a full label boundary', () => {
   // "evilapi.fliplet.test" ends with "api.fliplet.test" as a raw substring but
   // is not a subdomain of it.

--- a/widget.json
+++ b/widget.json
@@ -35,6 +35,7 @@
     ],
     "assets": [
       "css/lib/email_validation_build.css",
+      "js/safe-auth-host.js",
       "js/build.js",
       "css/build.css"
     ]


### PR DESCRIPTION
### Product areas affected
Fliplet Login widget (`js/build.js`) — the sign-in return leg on both web same-tab and native in-app-browser. No interface/build config changes.

### What does this PR do?
Reinstates the one-shot `authState` exchange stripped from the DEV-1572 release (PR #103, commits `dc8701e` / `a63ddb0`) and fixes the two blocking review findings that caused the revert. The widget sends `authExchange=1` on the login URL, then swaps the returned `authState` for the session via `GET /v1/session?state=` — so neither the session token nor the user payload ever transits a URL.

Paired with Fliplet/fliplet-api#8465 — **neither PR works alone.** Deploy the API first.

### JIRA ticket
[DEV-1633](https://weboo.atlassian.net/browse/DEV-1633)

### Result
Verified end-to-end in a real browser on a published local web app: sign-in completes, the callback carries `authState`/`authHost` and never `token=`/`user=`, the URL is scrubbed, and the `flipletLogin` passport is attached. A genuine cross-region login (US-only user against an EU app) returned `200` with the CORS preflight passing `204`.

**Review findings fixed:**

1. **Cross-region redemption (was BLOCKING, functional).** The reverted code built an absolute URL, but `Fliplet.API.request` prepends the API base to *every* url — absolute ones included (`core.js`: `options.url = apiUrl + options.url`, no scheme guard) — producing `https://api.fliplet.com/https://us-api.fliplet.com/…` → 404. So the cross-region case never worked. Now uses the supported `options.apiUrl` retarget (DEV-667). The ticket cited `core.js:1671-1688`; the actual code is at **1767-1784** (that range is `hashString`/`hashCode`) — the older line numbers appear to be from a pre-DEV-667 revision.

2. **`authHost` was an unvalidated request target (was BLOCKING, security).** On the same-tab leg it comes straight off the page query string and would become the host receiving `Authorization: Bearer`, with the response fed into `handleAuthSuccess`, which shape-validates the user but not its authenticity — credential exfiltration plus session fixation from a crafted link. `safeAuthHost()` now gates it.

3. **CORS (verify).** No change needed. `config.allowedOrigins` already includes every region's `host`/`apps_host`/`cdn_host`, and `libs/cors.js` sets no `allowedHeaders`, so the package reflects `Access-Control-Request-Headers`. Confirmed live: cross-region preflight returns `204` with all four custom headers reflected; a hostile origin gets no CORS headers.

Also adds `authHost` to `maskUrlForLogging` (not a credential, but masking it stops a log line revealing which region a user's session lives in).

### Checklist
 - [x] Added automated test coverage as appropriate for this change.

`safeAuthHost` is now in its own file (`js/safe-auth-host.js`) taking the app origin as an argument, which makes it a pure function testable outside a browser — `js/build.js` calls `Fliplet.Widget.instance` at module scope and cannot be loaded in Node.

**18 tests, `npm test` → `node --test`, no new dependency.** They cover the hostile inputs that previously only lived in a throwaway harness (suffix spoofs, query-string spoofs, userinfo `@` tricks, `javascript:`, protocol-relative, missing label boundaries) plus everything the two review rounds surfaced: the production CDN origins, sibling-rule depth, ports, and trailing-dot FQDNs.

Note the widget has **no CI running these** — Codacy is the only check and it reports `action_required` on every PR in this repo (#99 through #106 identical), which is an integration-authorisation state, not a finding against this branch. Wiring up a workflow to run `npm test` is worth doing but is arguably separate from this PR.

### Deployment instructions
Deploy Fliplet/fliplet-api#8465 **first**, then publish this widget. An old API ignores `authExchange=1` and keeps the legacy `token`+`user` contract, so the ordering is safe in both directions.

Native apps on a core bundle predating DEV-667 ignore `options.apiUrl` and degrade to same-region redemption rather than erroring.

### Author concerns

**1. The form branch has since been exercised — but region isolation still is not falsifiable.** A US-only user signing into an EU app completed sign-in through the form branch, and the **204 CORS preflight on the mint** proves `exchangeBase` was cross-origin: the auth page is served from the API host, so a same-origin mint does not preflight. Mint and redeem both targeted `us.api.fliplet.test`. What remains unproven is that a *wrong* host would fail — both regions share one Redis locally, so a misdirected redemption still resolves. Host targeting is confirmed; isolation needs two genuinely separate regional stacks or a staging pass.

**2. Two bugs found only because the app was served from the apps host.** In a published app `Fliplet.Env.get('apiUrl')` is the apps-host proxy while `primaryApiUrl` is the API host. `Fliplet.API.request` defaults to the former, so leaving `apiUrl` unset sent the exchange to `apps.fliplet.test`, not the canonical API host — every fallback path (rollout skew, tampered `authHost`, non-https) was affected. Now pinned to `safeAuthHost(authHost) || getApiOrigin()`. In Studio preview both values are identical and this would have stayed invisible.

**3. The allowlist initially rejected non-production regional hosts.** `us.api.fliplet.test` failed the `*.fliplet.com` test and fell back to the app's own host — passing locally only because the shared Redis resolves either way. That is the worst failure shape: correct in production, silently wrong off-production, masking cross-region bugs in exactly the environments used to test them. Now also accepts a single-label sibling of the app's own API host with a matching protocol, derived from the app's host so a crafted value cannot widen it, and **scoped off production** — on `fliplet.com` the regional-host rule is the whole allowlist, and a sibling rule there would readmit the CDN origins it exists to exclude. Deliberately **not** a registrable-domain ("last two labels") comparison — for an app on `api.acme.co.uk` that reduces to `co.uk` and would admit any `*.co.uk`.

**5. The allowlist needed two further narrowings after review.** `cdn.api.fliplet.com` and `cdn-staging.api.fliplet.com` are a *single label* under `api.fliplet.com` — structurally indistinguishable from a region — so they passed the regional-host rule and would have received the `Authorization` header; they are now explicitly excluded, and their two-label siblings (`us.cdn`, `ca.cdn`) were already out. Separately, every rule matched on `hostname` (port-free) while the function returned `origin` (port-bearing), so the port is now validated too. Both are covered by tests.

**4. Depends on an API-side core fix — and this is the real deploy gate.** This relies on Fliplet/fliplet-api#8465 correcting a `navigate.js` regex that silently dropped `authState` from `Fliplet.Navigate.query` and corrupted the `state` nonce. Without it the widget's `handleSameTabReturn()` bails at the first gate and sign-in never completes. Note this does **not** degrade to the legacy contract — it hard-breaks — and the asset's cache-buster is version-tied, so it does not change when the file does. The API PR carries the required mitigation (bump the `fliplet-core` asset version or republish) and a `config.disable_auth_exchange` kill switch that holds the exchange off until that lands.


[DEV-1633]: https://weboo.atlassian.net/browse/DEV-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
